### PR TITLE
Add `tag_info` to `Const_block`

### DIFF
--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -244,7 +244,7 @@ let emit_instr = function
           if i >= 0 && i <= 3
           then out (opCONST0 + i)
           else (out opCONSTINT; out_int i)
-      | Const_block(t, []) ->
+      | Const_block(t, [], _) ->
           if t = 0 then out opATOM0 else (out opATOM; out_int t)
       | _ ->
           out opGETGLOBAL; slot_for_literal sc
@@ -382,7 +382,7 @@ let rec emit = function
           if i >= 0 && i <= 3
           then out (opPUSHCONST0 + i)
           else (out opPUSHCONSTINT; out_int i)
-      | Const_block(t, []) ->
+      | Const_block(t, [], _) ->
           if t = 0 then out opPUSHATOM0 else (out opPUSHATOM; out_int t)
       | _ ->
           out opPUSHGETGLOBAL; slot_for_literal sc

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -157,7 +157,8 @@ let init () =
       let cst = Const_block(Obj.object_tag,
                             [Const_base(Const_string (name, None));
                              Const_base(Const_int (-i-1))
-                            ])
+                            ],
+                            Tag_none)
       in
       literal_table := (c, cst) :: !literal_table)
     Runtimedef.builtin_exceptions;
@@ -223,7 +224,7 @@ let rec transl_const = function
   | Const_base(Const_nativeint i) -> Obj.repr i
   | Const_pointer i -> Obj.repr i
   | Const_immstring s -> Obj.repr s
-  | Const_block(tag, fields) ->
+  | Const_block(tag, fields, _) ->
       let block = Obj.new_block tag (List.length fields) in
       let pos = ref 0 in
       List.iter

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -221,11 +221,14 @@ let equal_value_kind x y =
   | Pintval, Pintval -> true
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval), _ -> false
 
+type tag_info =
+  | Tag_none
+  | Tag_record
 
 type structured_constant =
     Const_base of constant
   | Const_pointer of int
-  | Const_block of int * structured_constant list
+  | Const_block of int * structured_constant list * tag_info
   | Const_float_array of string list
   | Const_immstring of string
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -213,10 +213,14 @@ val equal_value_kind : value_kind -> value_kind -> bool
 
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 
+type tag_info =
+  | Tag_none
+  | Tag_record
+
 type structured_constant =
     Const_base of constant
   | Const_pointer of int
-  | Const_block of int * structured_constant list
+  | Const_block of int * structured_constant list * tag_info
   | Const_float_array of string list
   | Const_immstring of string
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3347,7 +3347,7 @@ let partial_function loc () =
                      [ Const_base (Const_string (fname, None));
                        Const_base (Const_int line);
                        Const_base (Const_int char)
-                     ] ))
+                     ], Tag_none ))
             ],
             loc )
       ],
@@ -3452,7 +3452,7 @@ let assign_pat opt nraise catch_ids loc pat lam =
     | Tpat_tuple patl, Lprim (Pmakeblock _, lams, _) ->
         opt := true;
         List.fold_left2 collect acc patl lams
-    | Tpat_tuple patl, Lconst (Const_block (_, scl)) ->
+    | Tpat_tuple patl, Lconst (Const_block (_, scl, Tag_none)) ->
         opt := true;
         let collect_const acc pat sc = collect acc pat (Lconst sc) in
         List.fold_left2 collect_const acc patl scl

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -30,9 +30,9 @@ let rec struct_const ppf = function
   | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n
   | Const_base(Const_nativeint n) -> fprintf ppf "%nin" n
   | Const_pointer n -> fprintf ppf "%ia" n
-  | Const_block(tag, []) ->
+  | Const_block(tag, [], _) ->
       fprintf ppf "[%i]" tag
-  | Const_block(tag, sc1::scl) ->
+  | Const_block(tag, sc1::scl, _) ->
       let sconsts ppf scl =
         List.iter (fun sc -> fprintf ppf "@ %a" struct_const sc) scl in
       fprintf ppf "@[<1>[%i:@ @[%a%a@]]@]" tag struct_const sc1 sconsts scl

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -245,8 +245,8 @@ let simplify_exits lam =
          Lprim (Pmakeblock(tag, mut, shape), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
-         Lconst (Const_block (_, fields))] ->
-         Lconst (Const_block (tag, fields))
+         Lconst (Const_block (_, fields, Tag_none))] ->
+          Lconst (Const_block (tag, fields, Tag_none))
 
       | _ -> Lprim(p, ll, loc)
      end
@@ -341,7 +341,7 @@ let exact_application {kind; params; _} args =
           if List.length params <> List.length tupled_args
           then None
           else Some tupled_args
-      | [Lconst(Const_block (_, const_args))] ->
+      | [Lconst(Const_block (_, const_args, Tag_none))] ->
           if List.length params <> List.length const_args
           then None
           else Some (List.map (fun cst -> Lconst cst) const_args)

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -66,7 +66,7 @@ let transl_label l = share (Const_immstring l)
 let transl_meth_list lst =
   if lst = [] then Lconst (Const_pointer 0) else
   share (Const_block
-            (0, List.map (fun lab -> Const_immstring lab) lst))
+           (0, List.map (fun lab -> Const_immstring lab) lst, Tag_none))
 
 let set_inst_var obj id expr =
   Lprim(Psetfield_computed (Typeopt.maybe_pointer expr, Assignment),

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -179,7 +179,8 @@ let assert_failed exp =
            Lconst(Const_block(0,
               [Const_base(Const_string (fname, None));
                Const_base(Const_int line);
-               Const_base(Const_int char)]))], exp.exp_loc))], exp.exp_loc)
+               Const_base(Const_int char)],
+                              Tag_none))], exp.exp_loc))], exp.exp_loc)
 ;;
 
 let rec cut n l =
@@ -315,7 +316,7 @@ and transl_exp0 e =
   | Texp_tuple el ->
       let ll, shape = transl_list_with_shape el in
       begin try
-        Lconst(Const_block(0, List.map extract_constant ll))
+        Lconst(Const_block(0, List.map extract_constant ll, Tag_none))
       with Not_constant ->
         Lprim(Pmakeblock(0, Immutable, Some shape), ll, e.exp_loc)
       end
@@ -331,7 +332,7 @@ and transl_exp0 e =
           (match ll with [v] -> v | _ -> assert false)
       | Cstr_block n ->
           begin try
-            Lconst(Const_block(n, List.map extract_constant ll))
+            Lconst(Const_block(n, List.map extract_constant ll, Tag_none))
           with Not_constant ->
             Lprim(Pmakeblock(n, Immutable, Some shape), ll, e.exp_loc)
           end
@@ -352,7 +353,8 @@ and transl_exp0 e =
           let lam = transl_exp arg in
           try
             Lconst(Const_block(0, [Const_base(Const_int tag);
-                                   extract_constant lam]))
+                                   extract_constant lam],
+                              Tag_none))
           with Not_constant ->
             Lprim(Pmakeblock(0, Immutable, None),
                   [Lconst(Const_base(Const_int tag)); lam], e.exp_loc)
@@ -418,7 +420,7 @@ and transl_exp0 e =
             let imm_array =
               match kind with
               | Paddrarray | Pintarray ->
-                  Lconst(Const_block(0, cl))
+                  Lconst(Const_block(0, cl, Tag_none))
               | Pfloatarray ->
                   Lconst(Const_float_array(List.map extract_float cl))
               | Pgenarray ->
@@ -870,8 +872,8 @@ and transl_record loc env fields repres opt_init_expr =
         if mut = Mutable then raise Not_constant;
         let cl = List.map extract_constant ll in
         match repres with
-        | Record_regular -> Lconst(Const_block(0, cl))
-        | Record_inlined tag -> Lconst(Const_block(tag, cl))
+        | Record_regular -> Lconst(Const_block(0, cl, Tag_record))
+        | Record_inlined tag -> Lconst(Const_block(tag, cl, Tag_none))
         | Record_unboxed _ -> Lconst(match cl with [v] -> v | _ -> assert false)
         | Record_float ->
             Lconst(Const_float_array(List.map extract_float cl))

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -216,7 +216,8 @@ let undefined_location loc =
   Lconst(Const_block(0,
                      [Const_base(Const_string (fname, None));
                       Const_base(Const_int line);
-                      Const_base(Const_int char)]))
+                      Const_base(Const_int char)],
+                     Tag_none))
 
 exception Initialization_failure of unsafe_info
 
@@ -228,7 +229,7 @@ let init_shape id modl =
         raise (Initialization_failure
                 (Unsafe {reason=Unsafe_module_binding;loc;subid}))
     | Mty_signature sg ->
-        Const_block(0, [Const_block(0, init_shape_struct env sg)])
+        Const_block(0, [Const_block(0, init_shape_struct env sg, Tag_none)], Tag_none)
     | Mty_functor _ ->
         (* can we do better? *)
         raise (Initialization_failure

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -26,7 +26,7 @@ let consts : (structured_constant, Ident.t) Hashtbl.t = Hashtbl.create 17
 
 let share c =
   match c with
-    Const_block (_n, l) when l <> [] ->
+    Const_block (_n, l, _) when l <> [] ->
       begin try
         Lvar (Hashtbl.find consts c)
       with Not_found ->

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -643,7 +643,7 @@ let lambda_of_loc kind loc =
           Const_base (Const_int lnum);
           Const_base (Const_int cnum);
           Const_base (Const_int enum);
-        ]))
+        ], Tag_none))
   | Loc_FILE -> Lconst (Const_immstring file)
   | Loc_MODULE ->
     let filename = Filename.basename file in

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -860,7 +860,7 @@ let rec close ({ backend; fenv; cenv } as env) lam =
         | Const_base(Const_int n) -> Uconst_int n
         | Const_base(Const_char c) -> Uconst_int (Char.code c)
         | Const_pointer n -> Uconst_ptr n
-        | Const_block (tag, fields) ->
+        | Const_block (tag, fields, _) ->
             str (Uconst_block (tag, List.map transl fields))
         | Const_float_array sl ->
             (* constant float arrays are really immutable *)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -145,7 +145,7 @@ let rec declare_const t (const : Lambda.structured_constant)
     register_const t
       (Allocated_const (Immutable_float_array (List.map float_of_string c)))
       Names.const_float_array
-  | Const_block (tag, consts) ->
+  | Const_block (tag, consts, _) ->
     let const : Flambda.constant_defining_value =
       Block (Tag.create_exn tag,
              List.map (fun c -> fst (declare_const t c)) consts)

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -93,7 +93,7 @@ let rec print_struct_const = function
   | Const_base(Const_nativeint i) -> printf "%ndn" i
   | Const_base(Const_int64 i) -> printf "%LdL" i
   | Const_pointer n -> printf "%da" n
-  | Const_block(tag, args) ->
+  | Const_block(tag, args, _) ->
       printf "<%d>" tag;
       begin match args with
         [] -> ()


### PR DESCRIPTION
Adds an info field to `Const_block` structure for keeping track of what kind of data structure is created. Currently only records are tracked, but more types will probably be tracked in the future.