### PR TITLE
Track more info in lambda IR

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -813,7 +813,7 @@ let rec comp_expr env exp sz cont =
       let l = comp_expr env body (sz+4) body_cont in
       try_blocks := List.tl !try_blocks;
       Kpushtrap lbl_handler :: l
-  | Lifthenelse(cond, ifso, ifnot) ->
+  | Lifthenelse(cond, ifso, ifnot, _) ->
       comp_binary_test env cond ifso ifnot sz cont
   | Lsequence(exp1, exp2) ->
       comp_expr env exp1 sz (comp_expr env exp2 sz cont)

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -77,7 +77,7 @@ exception AsInt
 let const_as_int = function
   | Const_base(Const_int i) -> i
   | Const_base(Const_char c) -> Char.code c
-  | Const_pointer i -> i
+  | Const_pointer(i, _) -> i
   | _ -> raise AsInt
 
 let is_immed i = immed_min <= i && i <= immed_max
@@ -240,7 +240,7 @@ let emit_instr = function
           else (out opCONSTINT; out_int i)
       | Const_base(Const_char c) ->
           out opCONSTINT; out_int (Char.code c)
-      | Const_pointer i ->
+      | Const_pointer(i, _) ->
           if i >= 0 && i <= 3
           then out (opCONST0 + i)
           else (out opCONSTINT; out_int i)
@@ -378,7 +378,7 @@ let rec emit = function
           else (out opPUSHCONSTINT; out_int i)
       | Const_base(Const_char c) ->
           out opPUSHCONSTINT; out_int(Char.code c)
-      | Const_pointer i ->
+      | Const_pointer(i, _) ->
           if i >= 0 && i <= 3
           then out (opPUSHCONST0 + i)
           else (out opPUSHCONSTINT; out_int i)

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -222,7 +222,7 @@ let rec transl_const = function
   | Const_base(Const_int32 i) -> Obj.repr i
   | Const_base(Const_int64 i) -> Obj.repr i
   | Const_base(Const_nativeint i) -> Obj.repr i
-  | Const_pointer i -> Obj.repr i
+  | Const_pointer(i, _) -> Obj.repr i
   | Const_immstring s -> Obj.repr s
   | Const_block(tag, fields, _) ->
       let block = Obj.new_block tag (List.length fields) in

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -224,6 +224,7 @@ let equal_value_kind x y =
 type tag_info =
   | Tag_none
   | Tag_record
+  | Tag_con
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -41,8 +41,8 @@ type is_safe =
 
 type field_info =
   | Fnone
-  | Fmodule_access of string
-  | Frecord_access of string
+  | Fmodule of string
+  | Frecord of string
   | Frecord_inline of string
   | Ftuple
 
@@ -661,7 +661,7 @@ let rec transl_address loc path = function
       else Lvar id
   | Env.Adot(addr, pos) ->
       Lprim(Pfield(pos, Pointer,
-                   Immutable, Fmodule_access (Path.name path)),
+                   Immutable, Fmodule (Path.name path)),
             [transl_address loc path addr], loc)
 
 let transl_path find loc env path =

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -44,7 +44,7 @@ type field_info =
   | Fmodule of string
   | Frecord of string
   | Frecord_inline of string
-  | Fvariant
+  | Fcon
   | Ftuple
   | Fcons
 
@@ -233,8 +233,10 @@ type tag_info =
 
 type pointer_info =
   | Ptr_none
+  | Ptr_bool
   | Ptr_nil
   | Ptr_unit
+  | Ptr_con of string
 
 type structured_constant =
     Const_base of constant
@@ -309,6 +311,7 @@ type switch_names = {consts: string array; blocks: string array}
 type match_info =
     Match_none
   | Match_nil
+  | Match_con of string
 
 type lambda =
     Lvar of Ident.t

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -43,6 +43,8 @@ type field_info =
   | Fnone
   | Fmodule_access of string
   | Frecord_access of string
+  | Frecord_inline of string
+  | Ftuple
 
 type primitive =
   | Pidentity
@@ -225,6 +227,7 @@ type tag_info =
   | Tag_none
   | Tag_record
   | Tag_con of string
+  | Tag_tuple
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -44,7 +44,7 @@ type field_info =
   | Fmodule of string
   | Frecord of string
   | Frecord_inline of string
-  | Fcon
+  | Fcon of string
   | Ftuple
   | Fcons
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -229,9 +229,14 @@ type tag_info =
   | Tag_con of string
   | Tag_tuple
 
+type pointer_info =
+  | Ptr_none
+  | Ptr_nil
+  | Ptr_unit
+
 type structured_constant =
     Const_base of constant
-  | Const_pointer of int
+  | Const_pointer of int * pointer_info
   | Const_block of int * structured_constant list * tag_info
   | Const_float_array of string list
   | Const_immstring of string
@@ -365,7 +370,7 @@ type program =
     required_globals : Ident.Set.t;
     code : lambda }
 
-let const_unit = Const_pointer 0
+let const_unit = Const_pointer (0, Ptr_unit)
 
 let lambda_unit = Lconst const_unit
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -216,6 +216,7 @@ val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 type tag_info =
   | Tag_none
   | Tag_record
+  | Tag_con
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -50,7 +50,7 @@ type field_info =
   | Fmodule of string
   | Frecord of string
   | Frecord_inline of string
-  | Fcon
+  | Fcon of string
   | Ftuple
   | Fcons
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -47,8 +47,8 @@ type is_safe =
 
 type field_info =
   | Fnone
-  | Fmodule_access of string
-  | Frecord_access of string
+  | Fmodule of string
+  | Frecord of string
   | Frecord_inline of string
   | Ftuple
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -221,9 +221,14 @@ type tag_info =
   | Tag_con of string
   | Tag_tuple
 
+type pointer_info =
+  | Ptr_none
+  | Ptr_nil
+  | Ptr_unit
+
 type structured_constant =
     Const_base of constant
-  | Const_pointer of int
+  | Const_pointer of int * pointer_info
   | Const_block of int * structured_constant list * tag_info
   | Const_float_array of string list
   | Const_immstring of string

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -216,7 +216,7 @@ val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 type tag_info =
   | Tag_none
   | Tag_record
-  | Tag_con
+  | Tag_con of string
 
 type structured_constant =
     Const_base of constant
@@ -276,6 +276,9 @@ type function_attribute = {
   stub: bool;
 }
 
+(* Thanks ReScript: https://github.com/rescript-lang/rescript-compiler *)
+type switch_names = {consts: string array; blocks: string array}
+
 type lambda =
     Lvar of Ident.t
   | Lconst of structured_constant
@@ -324,7 +327,8 @@ and lambda_switch =
     sw_consts: (int * lambda) list;     (* Integer cases *)
     sw_numblocks: int;                  (* Number of tag block cases *)
     sw_blocks: (int * lambda) list;     (* Tag block cases *)
-    sw_failaction : lambda option}      (* Action to take if failure *)
+    sw_failaction : lambda option;      (* Action to take if failure *)
+    sw_names: switch_names option }     (* Names of targets *)
 and lambda_event =
   { lev_loc: Location.t;
     lev_kind: lambda_event_kind;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -49,6 +49,8 @@ type field_info =
   | Fnone
   | Fmodule_access of string
   | Frecord_access of string
+  | Frecord_inline of string
+  | Ftuple
 
 type primitive =
   | Pidentity
@@ -217,6 +219,7 @@ type tag_info =
   | Tag_none
   | Tag_record
   | Tag_con of string
+  | Tag_tuple
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -50,7 +50,7 @@ type field_info =
   | Fmodule of string
   | Frecord of string
   | Frecord_inline of string
-  | Fvariant
+  | Fcon
   | Ftuple
   | Fcons
 
@@ -225,8 +225,10 @@ type tag_info =
 
 type pointer_info =
   | Ptr_none
+  | Ptr_bool
   | Ptr_nil
   | Ptr_unit
+  | Ptr_con of string
 
 type structured_constant =
     Const_base of constant
@@ -292,6 +294,7 @@ type switch_names = {consts: string array; blocks: string array}
 type match_info =
     Match_none
   | Match_nil
+  | Match_con of string
 
 type lambda =
     Lvar of Ident.t

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -50,7 +50,9 @@ type field_info =
   | Fmodule of string
   | Frecord of string
   | Frecord_inline of string
+  | Fvariant
   | Ftuple
+  | Fcons
 
 type primitive =
   | Pidentity
@@ -287,6 +289,10 @@ type function_attribute = {
 (* Thanks ReScript: https://github.com/rescript-lang/rescript-compiler *)
 type switch_names = {consts: string array; blocks: string array}
 
+type match_info =
+    Match_none
+  | Match_nil
+
 type lambda =
     Lvar of Ident.t
   | Lconst of structured_constant
@@ -305,7 +311,7 @@ type lambda =
   | Ltrywith of lambda * Ident.t * lambda
 (* Lifthenelse (e, t, f) evaluates t if e evaluates to 0, and
    evaluates f if e evaluates to any other value *)
-  | Lifthenelse of lambda * lambda * lambda
+  | Lifthenelse of lambda * lambda * lambda * match_info
   | Lsequence of lambda * lambda
   | Lwhile of lambda * lambda
   | Lfor of Ident.t * lambda * lambda * direction_flag * lambda

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2696,7 +2696,7 @@ let split_extension_cases tag_lambda_list =
 
 let combine_constructor sw_names loc arg ex_pat cstr partial ctx def
     (tag_lambda_list, total1, pats) =
-cd  match cstr.cstr_tag with
+  match cstr.cstr_tag with
   | Cstr_extension _ ->
       (* Special cases for extensions *)
       let fail, local_jumps = mk_failaction_neg partial ctx def in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1626,7 +1626,7 @@ let make_constr_matching p def ctx = function
           | Cstr_constant _
           | Cstr_block _ ->
               make_field_args p.pat_loc Alias arg 0 (cstr.cstr_arity - 1) argl
-                ~field_info:(if cstr.cstr_name = "::" then Fcons else Fvariant)
+                ~field_info:(if cstr.cstr_name = "::" then Fcons else Fcon)
           | Cstr_unboxed -> (arg, Alias) :: argl
           | Cstr_extension _ ->
               make_field_args p.pat_loc Alias arg 1 cstr.cstr_arity argl
@@ -2758,7 +2758,12 @@ let combine_constructor sw_names loc arg ex_pat cstr partial ctx def
             | 1, 1, [ (0, act1) ], [ (0, act2) ] ->
                 (* Typically, match on lists, will avoid isint primitive in that
                    case *)
-                let info = if cstr.cstr_name = "[]" then Match_nil else Match_none in
+                (* print_endline cstr.cstr_name; *)
+                let info = begin
+                  match cstr.cstr_name with
+                  | "[]" -> Match_nil
+                  | s -> Match_con(s)
+                end in
                 Lifthenelse (arg, act2, act1, info)
             | n, 0, _, [] ->
                 (* The type defines constant constructors only *)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1626,7 +1626,8 @@ let make_constr_matching p def ctx = function
           | Cstr_constant _
           | Cstr_block _ ->
               make_field_args p.pat_loc Alias arg 0 (cstr.cstr_arity - 1) argl
-                ~field_info:(if cstr.cstr_name = "::" then Fcons else Fcon)
+                ~field_info:(if cstr.cstr_name = "::" then Fcons
+                             else Fcon cstr.cstr_name)
           | Cstr_unboxed -> (arg, Alias) :: argl
           | Cstr_extension _ ->
               make_field_args p.pat_loc Alias arg 1 cstr.cstr_arity argl

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1934,7 +1934,7 @@ let make_tuple_matching loc arity def = function
         if pos >= arity then
           argl
         else
-          (Lprim (Pfield (pos, Pointer, Immutable, Fnone), [ arg ], loc), Alias)
+          (Lprim (Pfield (pos, Pointer, Immutable, Ftuple), [ arg ], loc), Alias)
           :: make_args (pos + 1)
       in
       { cases = [];

--- a/lambda/matching.mli
+++ b/lambda/matching.mli
@@ -46,3 +46,5 @@ val expand_stringswitch:
     Location.t -> lambda -> (string * lambda) list -> lambda option -> lambda
 
 val inline_lazy_force : lambda -> Location.t -> lambda
+
+val names_from_construct_pattern : (pattern -> switch_names option) ref

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -168,8 +168,8 @@ let primitive ppf = function
   | Pfield(n, ptr, mut, finfo) ->
       let print_field = function
         | Fnone -> " "
-        | Fmodule_access s -> sprintf ":module_access(%s) " s
-        | Frecord_access s -> sprintf ":record_access(%s) " s
+        | Fmodule s -> sprintf ":module(%s) " s
+        | Frecord s -> sprintf ":record(%s) " s
         | Frecord_inline s -> sprintf ":record_inline(%s) " s
         | Ftuple -> ":tuple "
       in

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -23,6 +23,7 @@ let print_tag_info = function
   | Tag_none -> ""
   | Tag_record -> ":record"
   | Tag_con s -> sprintf ":con'%s'" s
+  | Tag_tuple -> ":tuple"
 
 let rec struct_const ppf = function
   | Const_base(Const_int n) -> fprintf ppf "%i" n
@@ -169,6 +170,8 @@ let primitive ppf = function
         | Fnone -> " "
         | Fmodule_access s -> sprintf ":module_access(%s) " s
         | Frecord_access s -> sprintf ":record_access(%s) " s
+        | Frecord_inline s -> sprintf ":record_inline(%s) " s
+        | Ftuple -> ":tuple "
       in
       let instr =
         match ptr, mut with

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -25,6 +25,11 @@ let print_tag_info = function
   | Tag_con s -> sprintf ":con'%s'" s
   | Tag_tuple -> ":tuple"
 
+let print_pointer_info = function
+  | Ptr_none -> ""
+  | Ptr_nil -> ":nil"
+  | Ptr_unit -> ":unit"
+
 let rec struct_const ppf = function
   | Const_base(Const_int n) -> fprintf ppf "%i" n
   | Const_base(Const_char c) -> fprintf ppf "%C" c
@@ -34,7 +39,8 @@ let rec struct_const ppf = function
   | Const_base(Const_int32 n) -> fprintf ppf "%lil" n
   | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n
   | Const_base(Const_nativeint n) -> fprintf ppf "%nin" n
-  | Const_pointer n -> fprintf ppf "%ia" n
+  | Const_pointer(n, pinfo) -> fprintf ppf "%ia%s" n
+                                 (print_pointer_info pinfo)
   | Const_block(tag, [], tinfo) ->
       fprintf ppf "[%i%s]" tag (print_tag_info tinfo)
   | Const_block(tag, sc1::scl, tinfo) ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -22,7 +22,7 @@ open Lambda
 let print_tag_info = function
   | Tag_none -> ""
   | Tag_record -> ":record"
-  | Tag_con -> ":con"
+  | Tag_con s -> sprintf ":con'%s'" s
 
 let rec struct_const ppf = function
   | Const_base(Const_int n) -> fprintf ppf "%i" n

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -27,8 +27,10 @@ let print_tag_info = function
 
 let print_pointer_info = function
   | Ptr_none -> ""
+  | Ptr_bool -> ":bool"
   | Ptr_nil -> ":nil"
   | Ptr_unit -> ":unit"
+  | Ptr_con(s) -> sprintf ":%s" s
 
 let rec struct_const ppf = function
   | Const_base(Const_int n) -> fprintf ppf "%i" n
@@ -177,7 +179,7 @@ let primitive ppf = function
         | Fmodule s -> sprintf ":module(%s) " s
         | Frecord s -> sprintf ":record(%s) " s
         | Frecord_inline s -> sprintf ":record_inline(%s) " s
-        | Fvariant -> ":variant"
+        | Fcon -> ":con"
         | Ftuple -> ":tuple "
         | Fcons -> ":cons"
       in
@@ -653,6 +655,7 @@ let rec lam ppf = function
       let print_match_info = function
         | Match_none -> ""
         | Match_nil -> ":[]"
+        | Match_con(s) -> sprintf ":%s" s
       in
       fprintf ppf "@[<2>(if@ %a%s@ %a@ %a)@]" lam lcond (print_match_info info)
         lam lif lam lelse

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -179,7 +179,7 @@ let primitive ppf = function
         | Fmodule s -> sprintf ":module(%s) " s
         | Frecord s -> sprintf ":record(%s) " s
         | Frecord_inline s -> sprintf ":record_inline(%s) " s
-        | Fcon -> ":con"
+        | Fcon s -> sprintf ":con'%s'" s
         | Ftuple -> ":tuple "
         | Fcons -> ":cons"
       in

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -177,7 +177,9 @@ let primitive ppf = function
         | Fmodule s -> sprintf ":module(%s) " s
         | Frecord s -> sprintf ":record(%s) " s
         | Frecord_inline s -> sprintf ":record_inline(%s) " s
+        | Fvariant -> ":variant"
         | Ftuple -> ":tuple "
+        | Fcons -> ":cons"
       in
       let instr =
         match ptr, mut with
@@ -647,8 +649,13 @@ let rec lam ppf = function
   | Ltrywith(lbody, param, lhandler) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -1>with %a@ %a)@]"
         lam lbody Ident.print param lam lhandler
-  | Lifthenelse(lcond, lif, lelse) ->
-      fprintf ppf "@[<2>(if@ %a@ %a@ %a)@]" lam lcond lam lif lam lelse
+  | Lifthenelse(lcond, lif, lelse, info) ->
+      let print_match_info = function
+        | Match_none -> ""
+        | Match_nil -> ":[]"
+      in
+      fprintf ppf "@[<2>(if@ %a%s@ %a@ %a)@]" lam lcond (print_match_info info)
+        lam lif lam lelse
   | Lsequence(l1, l2) ->
       fprintf ppf "@[<2>(seq@ %a@ %a)@]" lam l1 sequence l2
   | Lwhile(lcond, lbody) ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -56,7 +56,8 @@ let rec eliminate_ref id = function
          sw_blocks =
             List.map (fun (n, e) -> (n, eliminate_ref id e)) sw.sw_blocks;
          sw_failaction =
-            Option.map (eliminate_ref id) sw.sw_failaction; },
+           Option.map (eliminate_ref id) sw.sw_failaction;
+         sw_names = None },
         loc)
   | Lstringswitch(e, sw, default, loc) ->
       Lstringswitch

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -900,7 +900,7 @@ let transl_class ids cl_id pub_meths cl vflag =
          so that the program's behaviour does not change between runs *)
       lupdate_cache
     else
-      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache) in
+      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache, Match_none) in
   llets (
   lcache (
   Lsequence(lcheck_cache,

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -64,7 +64,7 @@ let lfield v i = Lprim(Pfield (i, Pointer, Mutable, Fnone),
 let transl_label l = share (Const_immstring l)
 
 let transl_meth_list lst =
-  if lst = [] then Lconst (Const_pointer 0) else
+  if lst = [] then Lconst (Const_pointer (0, Ptr_none)) else
   share (Const_block
            (0, List.map (fun lab -> Const_immstring lab) lst, Tag_none))
 
@@ -372,7 +372,7 @@ let rec build_class_init cla cstr super inh_init cl_init msubst top cl =
            Llet (Strict, Pgenval, inh,
                  mkappl(oo_prim "inherits", narrow_args @
                         [path_lam;
-                         Lconst(Const_pointer(if top then 1 else 0))]),
+                         Lconst(Const_pointer((if top then 1 else 0), Ptr_none))]),
                  Llet(StrictOpt, Pgenval, obj_init, lfield inh 0, cl_init)))
       | _ ->
           let core cl_init =
@@ -532,7 +532,7 @@ let rec builtin_meths self env env2 body =
     | Lprim(Parrayrefu _, [Lvar s; Lvar n], _) when List.mem s self ->
         "var", [Lvar n]
     | Lprim(Pfield(n, _, _, _), [Lvar e], _) when Ident.same e env ->
-        "env", [Lvar env2; Lconst(Const_pointer n)]
+        "env", [Lvar env2; Lconst(Const_pointer (n, Ptr_none))]
     | Lsend(Self, met, Lvar s, [], _) when List.mem s self ->
         "meth", [met]
     | _ -> raise Not_found
@@ -603,7 +603,7 @@ module M = struct
     | "send_env"   -> SendEnv
     | "send_meth"  -> SendMeth
     | _ -> assert false
-    in Lconst(Const_pointer(Obj.magic tag)) :: args
+    in Lconst(Const_pointer(Obj.magic tag, Ptr_none)) :: args
 end
 open M
 

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -332,7 +332,7 @@ and transl_exp0 e =
           (match ll with [v] -> v | _ -> assert false)
       | Cstr_block n ->
           begin try
-            Lconst(Const_block(n, List.map extract_constant ll, Tag_none))
+            Lconst(Const_block(n, List.map extract_constant ll, Tag_con))
           with Not_constant ->
             Lprim(Pmakeblock(n, Immutable, Some shape), ll, e.exp_loc)
           end

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -366,7 +366,7 @@ and transl_exp0 e =
       let targ = transl_exp arg in
       begin match lbl.lbl_repres with
           Record_regular | Record_inlined _ ->
-          Lprim (Pfield (lbl.lbl_pos, maybe_pointer e, lbl.lbl_mut, Frecord_access lbl.lbl_name),
+          Lprim (Pfield (lbl.lbl_pos, maybe_pointer e, lbl.lbl_mut, Frecord lbl.lbl_name),
                   [targ], e.exp_loc)
         | Record_unboxed _ -> targ
         | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [targ], e.exp_loc)
@@ -851,7 +851,7 @@ and transl_record loc env fields repres opt_init_expr =
                let access =
                  match repres with
                    Record_regular | Record_inlined _ ->
-                     Pfield (i, maybe_pointer_type env typ, mut, Frecord_access lbl.lbl_name)
+                     Pfield (i, maybe_pointer_type env typ, mut, Frecord lbl.lbl_name)
                  | Record_unboxed _ -> assert false
                  | Record_extension _ ->
                      Pfield (i + 1, maybe_pointer_type env typ, mut, Fnone)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -332,7 +332,7 @@ and transl_exp0 e =
           (match ll with [v] -> v | _ -> assert false)
       | Cstr_block n ->
           begin try
-            Lconst(Const_block(n, List.map extract_constant ll, Tag_con))
+            Lconst(Const_block(n, List.map extract_constant ll, Tag_con cstr.cstr_name))
           with Not_constant ->
             Lprim(Pmakeblock(n, Immutable, Some shape), ll, e.exp_loc)
           end

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -441,11 +441,12 @@ and transl_exp0 e =
   | Texp_ifthenelse(cond, ifso, Some ifnot) ->
       Lifthenelse(transl_exp cond,
                   event_before ifso (transl_exp ifso),
-                  event_before ifnot (transl_exp ifnot))
+                  event_before ifnot (transl_exp ifnot),
+                  Match_none)
   | Texp_ifthenelse(cond, ifso, None) ->
       Lifthenelse(transl_exp cond,
                   event_before ifso (transl_exp ifso),
-                  lambda_unit)
+                  lambda_unit, Match_none)
   | Texp_sequence(expr1, expr2) ->
       Lsequence(transl_exp expr1, event_before expr2 (transl_exp expr2))
   | Texp_while(cond, body) ->
@@ -525,7 +526,8 @@ and transl_exp0 e =
   | Texp_assert (cond) ->
       if !Clflags.noassert
       then lambda_unit
-      else Lifthenelse (transl_exp cond, lambda_unit, assert_failed e)
+      else Lifthenelse (transl_exp cond, lambda_unit, assert_failed e,
+                        Match_none)
   | Texp_lazy e ->
       (* when e needs no computation (constants, identifiers, ...), we
          optimize the translation just as Lazy.lazy_from_val would
@@ -622,7 +624,8 @@ and transl_guard guard rhs =
   match guard with
   | None -> expr
   | Some cond ->
-      event_before cond (Lifthenelse(transl_exp cond, expr, staticfail))
+      event_before cond (Lifthenelse(transl_exp cond, expr, staticfail,
+                                     Match_none))
 
 and transl_cont cont c_cont body =
   match cont, c_cont with

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -180,7 +180,7 @@ let assert_failed exp =
               [Const_base(Const_string (fname, None));
                Const_base(Const_int line);
                Const_base(Const_int char)],
-                              Tag_none))], exp.exp_loc))], exp.exp_loc)
+                              Tag_tuple))], exp.exp_loc))], exp.exp_loc)
 ;;
 
 let rec cut n l =
@@ -316,7 +316,7 @@ and transl_exp0 e =
   | Texp_tuple el ->
       let ll, shape = transl_list_with_shape el in
       begin try
-        Lconst(Const_block(0, List.map extract_constant ll, Tag_none))
+        Lconst(Const_block(0, List.map extract_constant ll, Tag_tuple))
       with Not_constant ->
         Lprim(Pmakeblock(0, Immutable, Some shape), ll, e.exp_loc)
       end

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -332,8 +332,10 @@ and transl_exp0 e =
                 Lconst(Const_pointer(n, Ptr_unit))
             | "[]" ->
                 Lconst(Const_pointer(n, Ptr_nil))
-            | _ ->
-                Lconst(Const_pointer(n, Ptr_none))
+            | "true" | "false" ->
+                Lconst(Const_pointer(n, Ptr_bool))
+            | s ->
+                Lconst(Const_pointer(n, Ptr_con s))
             end
         | Cstr_unboxed ->
             (match ll with [v] -> v | _ -> assert false)
@@ -355,7 +357,8 @@ and transl_exp0 e =
   | Texp_variant(l, arg) ->
       let tag = Btype.hash_variant l in
       begin match arg with
-        None -> Lconst(Const_pointer(tag, Ptr_none))
+        None ->
+          Lconst(Const_pointer(tag, Ptr_none))
       | Some arg ->
           let lam = transl_exp arg in
           try

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -241,9 +241,9 @@ let init_shape id modl =
         let init_v =
           match Ctype.expand_head env ty with
             {desc = Tarrow(_,_,_,_)} ->
-              Const_pointer 0 (* camlinternalMod.Function *)
+              Const_pointer (0, Ptr_none) (* camlinternalMod.Function *)
           | {desc = Tconstr(p, _, _)} when Path.same p Predef.path_lazy_t ->
-              Const_pointer 1 (* camlinternalMod.Lazy *)
+              Const_pointer (1, Ptr_none) (* camlinternalMod.Lazy *)
           | _ ->
               let not_a_function =
                 Unsafe {reason=Unsafe_non_function; loc; subid }
@@ -269,7 +269,7 @@ let init_shape id modl =
     | Sig_modtype(id, minfo, _) :: rem ->
         init_shape_struct (Env.add_modtype id minfo env) rem
     | Sig_class _ :: rem ->
-        Const_pointer 2 (* camlinternalMod.Class *)
+        Const_pointer (2, Ptr_none) (* camlinternalMod.Class *)
         :: init_shape_struct env rem
     | Sig_class_type _ :: rem ->
         init_shape_struct env rem

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -672,7 +672,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
   | Primitive (prim, arity), args when arity = List.length args ->
       Lprim(prim, args, loc)
   | External prim, args when prim = prim_sys_argv ->
-      Lprim(Pccall prim, Lconst (Const_pointer 0) :: args, loc)
+      Lprim(Pccall prim, Lconst (Const_pointer(0, Ptr_none)) :: args, loc)
   | External prim, args ->
       Lprim(Pccall prim, args, loc)
   | Comparison(comp, knd), ([_;_] as args) ->

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1137,7 +1137,7 @@ let rec close ({ backend; fenv; cenv } as env) lam =
       let (ubody, _) = close env body in
       let (uhandler, _) = close env handler in
       (Utrywith(ubody, VP.create id, uhandler), Value_unknown)
-  | Lifthenelse(arg, ifso, ifnot) ->
+  | Lifthenelse(arg, ifso, ifnot, _) ->
       begin match close env arg with
         (uarg, Value_const (Uconst_ptr n)) ->
           sequence_constant_expr uarg

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -859,7 +859,7 @@ let rec close ({ backend; fenv; cenv } as env) lam =
       let rec transl = function
         | Const_base(Const_int n) -> Uconst_int n
         | Const_base(Const_char c) -> Uconst_int (Char.code c)
-        | Const_pointer n -> Uconst_ptr n
+        | Const_pointer(n, _) -> Uconst_ptr n
         | Const_block (tag, fields, _) ->
             str (Uconst_block (tag, List.map transl fields))
         | Const_float_array sl ->

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -137,7 +137,7 @@ let rec declare_const t (const : Lambda.structured_constant)
       Names.const_int64
   | Const_base (Const_nativeint c) ->
     register_const t (Allocated_const (Nativeint c)) Names.const_nativeint
-  | Const_pointer c -> Const (Const_pointer c), Names.const_ptr
+  | Const_pointer(c, _) -> Const (Const_pointer c), Names.const_ptr
   | Const_immstring c ->
     register_const t (Allocated_const (Immutable_string c))
       Names.const_immstring
@@ -162,9 +162,9 @@ let close_const t (const : Lambda.structured_constant)
 
 let lambda_const_bool b : Lambda.structured_constant =
   if b then
-    Const_pointer 1
+    Const_pointer(1, Ptr_none)
   else
-    Const_pointer 0
+    Const_pointer(0, Ptr_none)
 
 let lambda_const_int i : Lambda.structured_constant =
   Const_base (Const_int i)
@@ -448,7 +448,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         | Ostype_win32 -> lambda_const_bool (String.equal Sys.os_type "Win32")
         | Ostype_cygwin -> lambda_const_bool (String.equal Sys.os_type "Cygwin")
         | Backend_type ->
-            Lambda.Const_pointer 0 (* tag 0 is the same as Native *)
+            Lambda.Const_pointer(0, Ptr_none) (* tag 0 is the same as Native *)
         end
       in
       close t env

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -527,7 +527,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Ltrywith (body, id, handler) ->
     let var = Variable.create_with_same_name_as_ident id in
     Try_with (close t env body, var, close t (Env.add_var env id var) handler)
-  | Lifthenelse (cond, ifso, ifnot) ->
+  | Lifthenelse (cond, ifso, ifnot, _) ->
     let cond = close t env cond in
     let cond_var = Variable.create Names.cond in
     Flambda.create_let cond_var (Expr cond)

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -92,7 +92,7 @@ let rec print_struct_const = function
   | Const_base(Const_int32 i) -> printf "%ldl" i
   | Const_base(Const_nativeint i) -> printf "%ndn" i
   | Const_base(Const_int64 i) -> printf "%LdL" i
-  | Const_pointer n -> printf "%da" n
+  | Const_pointer(n, _) -> printf "%da" n
   | Const_block(tag, args, _) ->
       printf "<%d>" tag;
       begin match args with


### PR DESCRIPTION
* Add `pointer_info` field to `Const_pointer`, to distinguish between Booleans, `unit`, `[]` and empty constructor.
* Add corresponding fields to if-then-else cases, to track when the condition is an empty list or constructor.
* Add more fields to `field_info`, to track constructors, tuples and, list `cons`.
* Add `Tag_con` to`tag_info`, to track names of constructors.