### PR TITLE
Add tag info to Pmakeblock

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -340,7 +340,7 @@ let comp_primitive p sz args =
     Pgetglobal id -> Kgetglobal id
   | Psetglobal id -> Ksetglobal id
   | Pintcomp cmp -> Kintcomp cmp
-  | Pmakeblock(tag, _mut, _) -> Kmakeblock(List.length args, tag)
+  | Pmakeblock(tag, _mut, _, _) -> Kmakeblock(List.length args, tag)
   | Pfield(n, _ptr, Immutable, _) -> Kgetfield n
   | Pfield(n, _ptr, Mutable, _) -> Kgetmutablefield n
   | Pfield_computed -> Kgetvectitem

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -48,6 +48,19 @@ type field_info =
   | Ftuple
   | Fcons
 
+type tag_info =
+  | Tag_none
+  | Tag_record
+  | Tag_con of string
+  | Tag_tuple
+
+type pointer_info =
+  | Ptr_none
+  | Ptr_bool
+  | Ptr_nil
+  | Ptr_unit
+  | Ptr_con of string
+
 type primitive =
   | Pidentity
   | Pbytes_to_string
@@ -59,7 +72,7 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * block_shape * tag_info
   | Pfield of int * immediate_or_pointer * mutable_flag * field_info
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
@@ -224,19 +237,6 @@ let equal_value_kind x y =
   | Pboxedintval bi1, Pboxedintval bi2 -> equal_boxed_integer bi1 bi2
   | Pintval, Pintval -> true
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval), _ -> false
-
-type tag_info =
-  | Tag_none
-  | Tag_record
-  | Tag_con of string
-  | Tag_tuple
-
-type pointer_info =
-  | Ptr_none
-  | Ptr_bool
-  | Ptr_nil
-  | Ptr_unit
-  | Ptr_con of string
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -54,6 +54,19 @@ type field_info =
   | Ftuple
   | Fcons
 
+type tag_info =
+  | Tag_none
+  | Tag_record
+  | Tag_con of string
+  | Tag_tuple
+
+type pointer_info =
+  | Ptr_none
+  | Ptr_bool
+  | Ptr_nil
+  | Ptr_unit
+  | Ptr_con of string
+
 type primitive =
   | Pidentity
   | Pbytes_to_string
@@ -65,7 +78,7 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * block_shape * tag_info
   | Pfield of int * immediate_or_pointer * mutable_flag * field_info
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
@@ -216,19 +229,6 @@ val equal_primitive : primitive -> primitive -> bool
 val equal_value_kind : value_kind -> value_kind -> bool
 
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
-
-type tag_info =
-  | Tag_none
-  | Tag_record
-  | Tag_con of string
-  | Tag_tuple
-
-type pointer_info =
-  | Ptr_none
-  | Ptr_bool
-  | Ptr_nil
-  | Ptr_unit
-  | Ptr_con of string
 
 type structured_constant =
     Const_base of constant

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3361,7 +3361,7 @@ let partial_function loc () =
   Lprim
     ( Praise Raise_regular,
       [ Lprim
-          ( Pmakeblock (0, Immutable, None),
+          ( Pmakeblock (0, Immutable, None, Tag_none),
             [ slot;
               Lconst
                 (Const_block
@@ -3609,7 +3609,7 @@ let do_for_multiple_match loc paraml pat_act_list partial =
     ( raise_num,
       { cases = List.map (fun (pat, act) -> ([ pat ], act)) pat_act_list;
         args =
-          [ (Lprim (Pmakeblock (0, Immutable, None), paraml, loc), Strict) ];
+          [ (Lprim (Pmakeblock (0, Immutable, None, Tag_none), paraml, loc), Strict) ];
         default
       } )
   in

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -169,10 +169,12 @@ let primitive ppf = function
   | Pdirapply -> fprintf ppf "dirapply"
   | Pgetglobal id -> fprintf ppf "global %a" Ident.print id
   | Psetglobal id -> fprintf ppf "setglobal %a" Ident.print id
-  | Pmakeblock(tag, Immutable, shape) ->
-      fprintf ppf "makeblock %i%a" tag block_shape shape
-  | Pmakeblock(tag, Mutable, shape) ->
-      fprintf ppf "makemutable %i%a" tag block_shape shape
+  | Pmakeblock(tag, Immutable, shape, info) ->
+      fprintf ppf "makeblock %i%s%a" tag (print_tag_info info)
+        block_shape shape
+  | Pmakeblock(tag, Mutable, shape, info) ->
+      fprintf ppf "makemutable %i%s%a" tag (print_tag_info info)
+        block_shape shape
   | Pfield(n, ptr, mut, finfo) ->
       let print_field = function
         | Fnone -> " "

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -243,8 +243,8 @@ let simplify_exits lam =
         (* Simplify Obj.with_tag *)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
-         Lprim (Pmakeblock (_, mut, shape), fields, loc)] ->
-         Lprim (Pmakeblock(tag, mut, shape), fields, loc)
+         Lprim (Pmakeblock (_, mut, shape, tag_info), fields, loc)] ->
+         Lprim (Pmakeblock(tag, mut, shape, tag_info), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
          Lconst (Const_block (_, fields, Tag_none))] ->
@@ -531,7 +531,7 @@ let simplify_lets lam =
       Hashtbl.add subst v (simplif (Lvar w));
       simplif l2
   | Llet(Strict, kind, v,
-         Lprim(Pmakeblock(0, Mutable, kind_ref) as prim, [linit], loc), lbody)
+         Lprim(Pmakeblock(0, Mutable, kind_ref, _) as prim, [linit], loc), lbody)
     when optimize ->
       let slinit = simplif linit in
       let slbody = simplif lbody in

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -245,7 +245,7 @@ let output_methods tbl methods lam =
       lsequence (mkappl(oo_prim "set_method", [Lvar tbl; lab; code])) lam
   | _ ->
       lsequence (mkappl(oo_prim "set_methods",
-                        [Lvar tbl; Lprim(Pmakeblock(0,Immutable,None),
+                        [Lvar tbl; Lprim(Pmakeblock(0,Immutable,None,Tag_none),
                                          methods, Location.none)]))
         lam
 
@@ -493,7 +493,7 @@ let transl_class_rebind cl vf =
     Strict, Pgenval, new_init, lfunction [obj_init, Pgenval] obj_init',
     Llet(
     Alias, Pgenval, cla, path_lam,
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           [mkappl(Lvar new_init, [lfield cla 0]);
            lfunction [table, Pgenval]
              (Llet(Strict, Pgenval, env_init,
@@ -789,12 +789,12 @@ let transl_class ids cl_id pub_meths cl vflag =
       Strict, Pgenval, env_init, mkappl (Lvar class_init, [Lvar table]),
       Lsequence(
       mkappl (oo_prim "init_class", [Lvar table]),
-      Lprim(Pmakeblock(0, Immutable, None),
+      Lprim(Pmakeblock(0, Immutable, None, Tag_none),
             [mkappl (Lvar env_init, [lambda_unit]);
              Lvar class_init; Lvar env_init; lambda_unit],
             Location.none))))
   and lbody_virt lenvs =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           [lambda_unit; Lfunction{kind = Curried;
                                   attr = default_function_attribute;
                                   loc = Location.none;
@@ -817,11 +817,11 @@ let transl_class ids cl_id pub_meths cl vflag =
   let lenv =
     let menv =
       if !new_ids_meths = [] then lambda_unit else
-      Lprim(Pmakeblock(0, Immutable, None),
+      Lprim(Pmakeblock(0, Immutable, None, Tag_none),
             List.map (fun id -> Lvar id) !new_ids_meths,
             Location.none) in
     if !new_ids_init = [] then menv else
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           menv :: List.map (fun id -> Lvar id) !new_ids_init,
           Location.none)
   and linh_envs =
@@ -833,7 +833,7 @@ let transl_class ids cl_id pub_meths cl vflag =
   let make_envs lam =
     Llet(StrictOpt, Pgenval, envs,
          (if linh_envs = [] then lenv else
-         Lprim(Pmakeblock(0, Immutable, None),
+         Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                lenv :: linh_envs, Location.none)),
          lam)
   and def_ids cla lam =
@@ -862,7 +862,7 @@ let transl_class ids cl_id pub_meths cl vflag =
     if inh_keys = [] then Llet(Alias, Pgenval, cached, Lvar tables, lam) else
     Llet(Strict, Pgenval, cached,
          mkappl (oo_prim "lookup_tables",
-                [Lvar tables; Lprim(Pmakeblock(0, Immutable, None),
+                [Lvar tables; Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                                     inh_keys, Location.none)]),
          lam)
   and lset cached i lam =
@@ -906,7 +906,7 @@ let transl_class ids cl_id pub_meths cl vflag =
   Lsequence(lcheck_cache,
   make_envs (
   if ids = [] then mkappl (lfield cached 0, [lenvs]) else
-  Lprim(Pmakeblock(0, Immutable, None),
+  Lprim(Pmakeblock(0, Immutable, None, Tag_none),
         (if concrete then
           [mkappl (lfield cached 0, [lenvs]);
            lfield cached 1;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -60,7 +60,7 @@ let transl_extension_constructor env path ext =
   let loc = ext.ext_loc in
   match ext.ext_kind with
     Text_decl _ ->
-      Lprim (Pmakeblock (Obj.object_tag, Immutable, None),
+      Lprim (Pmakeblock (Obj.object_tag, Immutable, None, Tag_none),
         [Lconst (Const_base (Const_string (name, None)));
          Lprim (prim_fresh_oo_id, [Lconst (Const_base (Const_int 0))], loc)],
         loc)
@@ -174,7 +174,7 @@ let assert_failed exp =
     Location.get_pos_info exp.exp_loc.Location.loc_start
   in
   Lprim(Praise Raise_regular, [event_after exp
-    (Lprim(Pmakeblock(0, Immutable, None),
+    (Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           [slot;
            Lconst(Const_block(0,
               [Const_base(Const_string (fname, None));
@@ -318,7 +318,7 @@ and transl_exp0 e =
       begin try
         Lconst(Const_block(0, List.map extract_constant ll, Tag_tuple))
       with Not_constant ->
-        Lprim(Pmakeblock(0, Immutable, Some shape), ll, e.exp_loc)
+        Lprim(Pmakeblock(0, Immutable, Some shape, Tag_none), ll, e.exp_loc)
       end
   | Texp_construct(_, cstr, args) ->
       let ll, shape = transl_list_with_shape args in
@@ -340,16 +340,17 @@ and transl_exp0 e =
         | Cstr_unboxed ->
             (match ll with [v] -> v | _ -> assert false)
         | Cstr_block n ->
+            let tag_info = Tag_con cstr.cstr_name in
             begin try
-              Lconst(Const_block(n, List.map extract_constant ll, Tag_con cstr.cstr_name))
+              Lconst(Const_block(n, List.map extract_constant ll, tag_info))
             with Not_constant ->
-              Lprim(Pmakeblock(n, Immutable, Some shape), ll, e.exp_loc)
+              Lprim(Pmakeblock(n, Immutable, Some shape, tag_info), ll, e.exp_loc)
             end
         | Cstr_extension(path, is_const) ->
             let lam = transl_extension_path e.exp_loc e.exp_env path in
             if is_const then lam
             else
-              Lprim(Pmakeblock(0, Immutable, Some (Pgenval :: shape)),
+              Lprim(Pmakeblock(0, Immutable, Some (Pgenval :: shape), Tag_none),
                     lam :: ll, e.exp_loc)
       end
   | Texp_extension_constructor (_, path) ->
@@ -366,7 +367,7 @@ and transl_exp0 e =
                                    extract_constant lam],
                               Tag_none))
           with Not_constant ->
-            Lprim(Pmakeblock(0, Immutable, None),
+            Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                   [Lconst(Const_base(Const_int tag)); lam], e.exp_loc)
       end
   | Texp_record {fields; representation; extended_expression} ->
@@ -544,7 +545,7 @@ and transl_exp0 e =
           (* We don't need to wrap with Popaque: this forward
              block will never be shortcutted since it points to a float
              and Config.flat_float_array is true. *)
-          Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),
+          Lprim(Pmakeblock(Obj.forward_tag, Immutable, None, Tag_none),
                 [transl_exp e], e.exp_loc)
       | `Identifier `Forward_value ->
          (* CR-someday mshinwell: Consider adding a new primitive
@@ -554,7 +555,7 @@ and transl_exp0 e =
             block doesn't really match what is going on here.  This
             value may subsequently turn into an immediate... *)
          Lprim (Popaque,
-                [Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),
+                [Lprim(Pmakeblock(Obj.forward_tag, Immutable, None, Tag_none),
                        [transl_exp e], e.exp_loc)],
                 e.exp_loc)
       | `Identifier `Other ->
@@ -567,7 +568,7 @@ and transl_exp0 e =
                              attr = default_function_attribute;
                              loc = e.exp_loc;
                              body = transl_exp e} in
-          Lprim(Pmakeblock(Config.lazy_tag, Mutable, None), [fn], e.exp_loc)
+          Lprim(Pmakeblock(Config.lazy_tag, Mutable, None, Tag_none), [fn], e.exp_loc)
       end
   | Texp_object (cs, meths) ->
       let cty = cs.cstr_type in
@@ -895,15 +896,15 @@ and transl_record loc env fields repres opt_init_expr =
       with Not_constant ->
         match repres with
           Record_regular ->
-            Lprim(Pmakeblock(0, mut, Some shape), ll, loc)
+            Lprim(Pmakeblock(0, mut, Some shape, Tag_none), ll, loc)
         | Record_inlined tag ->
-            Lprim(Pmakeblock(tag, mut, Some shape), ll, loc)
+            Lprim(Pmakeblock(tag, mut, Some shape, Tag_none), ll, loc)
         | Record_unboxed _ -> (match ll with [v] -> v | _ -> assert false)
         | Record_float ->
             Lprim(Pmakearray (Pfloatarray, mut), ll, loc)
         | Record_extension path ->
             let slot = transl_extension_path loc env path in
-            Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape)), slot :: ll, loc)
+            Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape), Tag_none), slot :: ll, loc)
     in
     begin match opt_init_expr with
       None -> lam

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -84,7 +84,7 @@ let rec apply_coercion loc strict restr arg =
           else Lprim(Pfield (pos, Pointer, Mutable, Fnone), [Lvar id], loc)
         in
         let lam =
-          Lprim(Pmakeblock(0, Immutable, None),
+          Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                 List.map (apply_coercion_field loc get_field) pos_cc_list,
                 loc)
         in
@@ -531,7 +531,7 @@ and transl_structure loc fields cc rootpath final_env = function
       let body, size =
         match cc with
           Tcoerce_none ->
-            Lprim(Pmakeblock(0, Immutable, None),
+            Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                   List.map (fun id -> Lvar id) (List.rev fields), loc),
               List.length fields
         | Tcoerce_structure(pos_cc_list, id_pos_list) ->
@@ -547,7 +547,7 @@ and transl_structure loc fields cc rootpath final_env = function
             in
             let ids = List.fold_right Ident.Set.add fields Ident.Set.empty in
             let lam =
-              Lprim(Pmakeblock(0, Immutable, None),
+              Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                   List.map
                     (fun (pos, cc) ->
                       match cc with
@@ -1050,7 +1050,7 @@ let transl_store_structure glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                                     List.map (fun id -> Lvar id)
                                       (defined_idents str.str_items), loc)),
                            Lsequence(store_ident loc id,
@@ -1079,7 +1079,7 @@ let transl_store_structure glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                                     List.map field map, loc)),
                            Lsequence(store_ident loc id,
                                      transl_store rootpath
@@ -1531,13 +1531,13 @@ let transl_package_flambda component_names coercion =
   in
   size,
   apply_coercion Location.none Strict coercion
-    (Lprim(Pmakeblock(0, Immutable, None),
+    (Lprim(Pmakeblock(0, Immutable, None, Tag_none),
            List.map get_component component_names,
            Location.none))
 
 let transl_package component_names target_name coercion =
   let components =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           List.map get_component component_names, Location.none) in
   Lprim(Psetglobal target_name,
         [apply_coercion Location.none Strict coercion components],
@@ -1575,7 +1575,7 @@ let transl_store_package component_names target_name coercion =
          0 component_names)
   | Tcoerce_structure (pos_cc_list, _id_pos_list) ->
       let components =
-        Lprim(Pmakeblock(0, Immutable, None),
+        Lprim(Pmakeblock(0, Immutable, None, Tag_none),
               List.map get_component component_names,
               Location.none)
       in

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -179,7 +179,7 @@ let oo_wrap env req f x =
            List.fold_left
              (fun lambda id ->
                 Llet(StrictOpt, Pgenval, id,
-                     Lprim(Pmakeblock(0, Mutable, None),
+                     Lprim(Pmakeblock(0, Mutable, None, Tag_none),
                            [lambda_unit; lambda_unit; lambda_unit],
                            Location.none),
                      lambda))

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -123,8 +123,8 @@ let primitives_table =
     "%field0", Primitive (Pfield(0, Pointer, Mutable, Fnone), 1);
     "%field1", Primitive (Pfield(1, Pointer, Mutable, Fnone), 1);
     "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
-    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
-    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
+    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None, Tag_none)), 1);
+    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None, Tag_none)), 1);
     "%raise", Raise Raise_regular;
     "%reraise", Raise Raise_reraise;
     "%raise_notrace", Raise Raise_notrace;
@@ -472,10 +472,11 @@ let specialize_primitive env ty ~has_constant_constructor prim =
       | Pbigarray_unknown, Pbigarray_unknown_layout -> None
       | _, _ -> Some (Primitive (Pbigarrayset(unsafe, n, k, l), arity))
     end
-  | Primitive (Pmakeblock(tag, mut, None), arity), fields -> begin
+  | Primitive (Pmakeblock(tag, mut, None, tag_info), arity), fields -> begin
       let shape = List.map (Typeopt.value_kind env) fields in
       let useful = List.exists (fun knd -> knd <> Pgenval) shape in
-      if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape), arity))
+      if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape, tag_info),
+                                      arity))
       else None
     end
   | Primitive (Patomic_load { immediate_or_pointer = Pointer }, arity), _ -> begin
@@ -712,7 +713,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
       lambda_of_loc kind loc
   | Loc kind, [arg] ->
       let lam = lambda_of_loc kind loc in
-      Lprim(Pmakeblock(0, Immutable, None), [lam; arg], loc)
+      Lprim(Pmakeblock(0, Immutable, None, Tag_none), [lam; arg], loc)
   | Send, [obj; meth] ->
       Lsend(Public, meth, obj, [], loc)
   | Send_self, [obj; meth] ->

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -24,7 +24,7 @@ let convert_unsafety is_unsafe : Clambda_primitives.is_safe =
 
 let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
-  | Pmakeblock (tag, mutability, shape) ->
+  | Pmakeblock (tag, mutability, shape, _) ->
       Pmakeblock (tag, mutability, shape)
   | Pfield (field, imm_or_pointer, mutability, _) ->
       Pfield (field, imm_or_pointer, mutability)


### PR DESCRIPTION
In order to track the type of a `Pmakeblock` primitive. Right now, only `cons` operations are tracked, but more will be tracked in the future.