### PR TITLE
Create multicore flambda opam switch

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -340,7 +340,7 @@ let comp_primitive p sz args =
     Pgetglobal id -> Kgetglobal id
   | Psetglobal id -> Ksetglobal id
   | Pintcomp cmp -> Kintcomp cmp
-  | Pmakeblock(tag, _mut, _) -> Kmakeblock(List.length args, tag)
+  | Pmakeblock(tag, _mut, _, _) -> Kmakeblock(List.length args, tag)
   | Pfield(n, _ptr, Immutable, _) -> Kgetfield n
   | Pfield(n, _ptr, Mutable, _) -> Kgetmutablefield n
   | Pfield_computed -> Kgetvectitem

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -813,7 +813,7 @@ let rec comp_expr env exp sz cont =
       let l = comp_expr env body (sz+4) body_cont in
       try_blocks := List.tl !try_blocks;
       Kpushtrap lbl_handler :: l
-  | Lifthenelse(cond, ifso, ifnot) ->
+  | Lifthenelse(cond, ifso, ifnot, _) ->
       comp_binary_test env cond ifso ifnot sz cont
   | Lsequence(exp1, exp2) ->
       comp_expr env exp1 sz (comp_expr env exp2 sz cont)

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -341,8 +341,8 @@ let comp_primitive p sz args =
   | Psetglobal id -> Ksetglobal id
   | Pintcomp cmp -> Kintcomp cmp
   | Pmakeblock(tag, _mut, _) -> Kmakeblock(List.length args, tag)
-  | Pfield(n, _ptr, Immutable) -> Kgetfield n
-  | Pfield(n, _ptr, Mutable) -> Kgetmutablefield n
+  | Pfield(n, _ptr, Immutable, _) -> Kgetfield n
+  | Pfield(n, _ptr, Mutable, _) -> Kgetmutablefield n
   | Pfield_computed -> Kgetvectitem
   | Psetfield(n, _ptr, _init) -> Ksetfield n
   | Psetfield_computed(_ptr, _init) -> Ksetvectitem

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -77,7 +77,7 @@ exception AsInt
 let const_as_int = function
   | Const_base(Const_int i) -> i
   | Const_base(Const_char c) -> Char.code c
-  | Const_pointer i -> i
+  | Const_pointer(i, _) -> i
   | _ -> raise AsInt
 
 let is_immed i = immed_min <= i && i <= immed_max
@@ -240,7 +240,7 @@ let emit_instr = function
           else (out opCONSTINT; out_int i)
       | Const_base(Const_char c) ->
           out opCONSTINT; out_int (Char.code c)
-      | Const_pointer i ->
+      | Const_pointer(i, _) ->
           if i >= 0 && i <= 3
           then out (opCONST0 + i)
           else (out opCONSTINT; out_int i)
@@ -378,7 +378,7 @@ let rec emit = function
           else (out opPUSHCONSTINT; out_int i)
       | Const_base(Const_char c) ->
           out opPUSHCONSTINT; out_int(Char.code c)
-      | Const_pointer i ->
+      | Const_pointer(i, _) ->
           if i >= 0 && i <= 3
           then out (opPUSHCONST0 + i)
           else (out opPUSHCONSTINT; out_int i)

--- a/bytecomp/emitcode.ml
+++ b/bytecomp/emitcode.ml
@@ -244,7 +244,7 @@ let emit_instr = function
           if i >= 0 && i <= 3
           then out (opCONST0 + i)
           else (out opCONSTINT; out_int i)
-      | Const_block(t, []) ->
+      | Const_block(t, [], _) ->
           if t = 0 then out opATOM0 else (out opATOM; out_int t)
       | _ ->
           out opGETGLOBAL; slot_for_literal sc
@@ -382,7 +382,7 @@ let rec emit = function
           if i >= 0 && i <= 3
           then out (opPUSHCONST0 + i)
           else (out opPUSHCONSTINT; out_int i)
-      | Const_block(t, []) ->
+      | Const_block(t, [], _) ->
           if t = 0 then out opPUSHATOM0 else (out opPUSHATOM; out_int t)
       | _ ->
           out opPUSHGETGLOBAL; slot_for_literal sc

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -157,7 +157,8 @@ let init () =
       let cst = Const_block(Obj.object_tag,
                             [Const_base(Const_string (name, None));
                              Const_base(Const_int (-i-1))
-                            ])
+                            ],
+                            Tag_none)
       in
       literal_table := (c, cst) :: !literal_table)
     Runtimedef.builtin_exceptions;
@@ -223,7 +224,7 @@ let rec transl_const = function
   | Const_base(Const_nativeint i) -> Obj.repr i
   | Const_pointer i -> Obj.repr i
   | Const_immstring s -> Obj.repr s
-  | Const_block(tag, fields) ->
+  | Const_block(tag, fields, _) ->
       let block = Obj.new_block tag (List.length fields) in
       let pos = ref 0 in
       List.iter

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -222,7 +222,7 @@ let rec transl_const = function
   | Const_base(Const_int32 i) -> Obj.repr i
   | Const_base(Const_int64 i) -> Obj.repr i
   | Const_base(Const_nativeint i) -> Obj.repr i
-  | Const_pointer i -> Obj.repr i
+  | Const_pointer(i, _) -> Obj.repr i
   | Const_immstring s -> Obj.repr s
   | Const_block(tag, fields, _) ->
       let block = Obj.new_block tag (List.length fields) in

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -48,6 +48,19 @@ type field_info =
   | Ftuple
   | Fcons
 
+type tag_info =
+  | Tag_none
+  | Tag_record
+  | Tag_con of string
+  | Tag_tuple
+
+type pointer_info =
+  | Ptr_none
+  | Ptr_bool
+  | Ptr_nil
+  | Ptr_unit
+  | Ptr_con of string
+
 type primitive =
   | Pidentity
   | Pbytes_to_string
@@ -59,7 +72,7 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * block_shape * tag_info
   | Pfield of int * immediate_or_pointer * mutable_flag * field_info
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
@@ -224,19 +237,6 @@ let equal_value_kind x y =
   | Pboxedintval bi1, Pboxedintval bi2 -> equal_boxed_integer bi1 bi2
   | Pintval, Pintval -> true
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval), _ -> false
-
-type tag_info =
-  | Tag_none
-  | Tag_record
-  | Tag_con of string
-  | Tag_tuple
-
-type pointer_info =
-  | Ptr_none
-  | Ptr_bool
-  | Ptr_nil
-  | Ptr_unit
-  | Ptr_con of string
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -221,11 +221,14 @@ let equal_value_kind x y =
   | Pintval, Pintval -> true
   | (Pgenval | Pfloatval | Pboxedintval _ | Pintval), _ -> false
 
+type tag_info =
+  | Tag_none
+  | Tag_record
 
 type structured_constant =
     Const_base of constant
   | Const_pointer of int
-  | Const_block of int * structured_constant list
+  | Const_block of int * structured_constant list * tag_info
   | Const_float_array of string list
   | Const_immstring of string
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -213,10 +213,14 @@ val equal_value_kind : value_kind -> value_kind -> bool
 
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
 
+type tag_info =
+  | Tag_none
+  | Tag_record
+
 type structured_constant =
     Const_base of constant
   | Const_pointer of int
-  | Const_block of int * structured_constant list
+  | Const_block of int * structured_constant list * tag_info
   | Const_float_array of string list
   | Const_immstring of string
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -54,6 +54,19 @@ type field_info =
   | Ftuple
   | Fcons
 
+type tag_info =
+  | Tag_none
+  | Tag_record
+  | Tag_con of string
+  | Tag_tuple
+
+type pointer_info =
+  | Ptr_none
+  | Ptr_bool
+  | Ptr_nil
+  | Ptr_unit
+  | Ptr_con of string
+
 type primitive =
   | Pidentity
   | Pbytes_to_string
@@ -65,7 +78,7 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * block_shape * tag_info
   | Pfield of int * immediate_or_pointer * mutable_flag * field_info
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
@@ -216,19 +229,6 @@ val equal_primitive : primitive -> primitive -> bool
 val equal_value_kind : value_kind -> value_kind -> bool
 
 val equal_boxed_integer : boxed_integer -> boxed_integer -> bool
-
-type tag_info =
-  | Tag_none
-  | Tag_record
-  | Tag_con of string
-  | Tag_tuple
-
-type pointer_info =
-  | Ptr_none
-  | Ptr_bool
-  | Ptr_nil
-  | Ptr_unit
-  | Ptr_con of string
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -45,6 +45,11 @@ type is_safe =
   | Safe
   | Unsafe
 
+type field_info =
+  | Fnone
+  | Fmodule_access of string
+  | Frecord_access of string
+
 type primitive =
   | Pidentity
   | Pbytes_to_string
@@ -57,7 +62,7 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int * immediate_or_pointer * mutable_flag
+  | Pfield of int * immediate_or_pointer * mutable_flag * field_info
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1529,12 +1529,12 @@ let divide_constant ctx m =
 
 (* Matching against a constructor *)
 
-let make_field_args loc binding_kind arg first_pos last_pos argl =
+let make_field_args ?field_info:(field_info=Fnone) loc binding_kind arg first_pos last_pos argl =
   let rec make_args pos =
     if pos > last_pos then
       argl
     else
-      (Lprim (Pfield(pos, Pointer, Immutable, Fnone), [ arg ], loc),
+      (Lprim (Pfield(pos, Pointer, Immutable, field_info), [ arg ], loc),
           binding_kind) :: make_args (pos + 1)
   in
   make_args first_pos
@@ -1626,6 +1626,8 @@ let make_constr_matching p def ctx = function
           | Cstr_constant _
           | Cstr_block _ ->
               make_field_args p.pat_loc Alias arg 0 (cstr.cstr_arity - 1) argl
+                ~field_info:(if cstr.cstr_name = "::" then Fcons
+                             else Fcon cstr.cstr_name)
           | Cstr_unboxed -> (arg, Alias) :: argl
           | Cstr_extension _ ->
               make_field_args p.pat_loc Alias arg 1 cstr.cstr_arity argl
@@ -1827,7 +1829,7 @@ let inline_lazy_force_cond arg loc =
                       ap_specialised = Default_specialise
                     },
                   (* ... arg *)
-                  varg ) ) ) )
+                  varg, Match_none ), Match_none) ) )
 
 let inline_lazy_force_switch arg loc =
   let idarg = Ident.create_local "lzarg" in
@@ -1872,9 +1874,10 @@ let inline_lazy_force_switch arg loc =
                           ap_specialised = Default_specialise
                         } )
                   ];
-                sw_failaction = Some varg
+                sw_failaction = Some varg;
+                sw_names = None
               },
-              loc ) ) )
+              loc ), Match_none ) )
 
 let inline_lazy_force arg loc =
   if !Clflags.afl_instrument then
@@ -1933,7 +1936,7 @@ let make_tuple_matching loc arity def = function
         if pos >= arity then
           argl
         else
-          (Lprim (Pfield (pos, Pointer, Immutable, Fnone), [ arg ], loc), Alias)
+          (Lprim (Pfield (pos, Pointer, Immutable, Ftuple), [ arg ], loc), Alias)
           :: make_args (pos + 1)
       in
       { cases = [];
@@ -2101,7 +2104,8 @@ let make_string_test_sequence loc arg sw d =
                   [ arg; Lconst (Const_immstring str) ],
                   loc ),
               k,
-              lam ))
+              lam,
+              Match_none))
         sw d)
 
 let rec split k xs =
@@ -2120,7 +2124,8 @@ let tree_way_test loc arg lt eq gt =
   Lifthenelse
     ( Lprim (Pintcomp Clt, [ arg; zero_lam ], loc),
       lt,
-      Lifthenelse (Lprim (Pintcomp Clt, [ zero_lam; arg ], loc), gt, eq) )
+      Lifthenelse (Lprim (Pintcomp Clt, [ zero_lam; arg ], loc), gt, eq, Match_none),
+      Match_none)
 
 (* Dichotomic tree *)
 
@@ -2215,7 +2220,8 @@ let rec do_tests_fail loc fail tst arg = function
       Lifthenelse
         ( Lprim (tst, [ arg; Lconst (Const_base c) ], loc),
           do_tests_fail loc fail tst arg rem,
-          act )
+          act,
+          Match_none)
 
 let rec do_tests_nofail loc tst arg = function
   | [] -> fatal_error "Matching.do_tests_nofail"
@@ -2224,7 +2230,8 @@ let rec do_tests_nofail loc tst arg = function
       Lifthenelse
         ( Lprim (tst, [ arg; Lconst (Const_base c) ], loc),
           do_tests_nofail loc tst arg rem,
-          act )
+          act,
+          Match_none)
 
 let make_test_sequence loc fail tst lt_tst arg const_lambda_list =
   let const_lambda_list = sort_lambda_list const_lambda_list in
@@ -2245,7 +2252,8 @@ let make_test_sequence loc fail tst lt_tst arg const_lambda_list =
     Lifthenelse
       ( Lprim (lt_tst, [ arg; Lconst (Const_base (fst (List.hd list2))) ], loc),
         make_test_sequence list1,
-        make_test_sequence list2 )
+        make_test_sequence list2,
+        Match_none )
   in
   hs (make_test_sequence const_lambda_list)
 
@@ -2289,7 +2297,7 @@ module SArg = struct
 
   let make_isin h arg = Lprim (Pnot, [ make_isout h arg ], Location.none)
 
-  let make_if cond ifso ifnot = Lifthenelse (cond, ifso, ifnot)
+  let make_if cond ifso ifnot = Lifthenelse (cond, ifso, ifnot, Match_none)
 
   let make_switch loc arg cases acts =
     let l = ref [] in
@@ -2302,7 +2310,8 @@ module SArg = struct
           sw_consts = !l;
           sw_numblocks = 0;
           sw_blocks = [];
-          sw_failaction = None
+          sw_failaction = None;
+          sw_names = None
         },
         loc )
 
@@ -2686,7 +2695,7 @@ let split_extension_cases tag_lambda_list =
   in
   split_rec tag_lambda_list
 
-let combine_constructor loc arg ex_pat cstr partial ctx def
+let combine_constructor sw_names loc arg ex_pat cstr partial ctx def
     (tag_lambda_list, total1, pats) =
   match cstr.cstr_tag with
   | Cstr_extension _ ->
@@ -2714,7 +2723,7 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
                   (fun (path, act) rem ->
                     let ext = transl_extension_path loc ex_pat.pat_env path in
                     Lifthenelse
-                      (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem))
+                      (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem, Match_none))
                   nonconsts default
               in
               Llet (Alias, Pgenval, tag,
@@ -2723,7 +2732,7 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
         List.fold_right
           (fun (path, act) rem ->
             let ext = transl_extension_path loc ex_pat.pat_env path in
-            Lifthenelse (Lprim (Pintcomp Ceq, [ arg; ext ], loc), act, rem))
+            Lifthenelse (Lprim (Pintcomp Ceq, [ arg; ext ], loc), act, rem, Match_none))
           consts nonconst_lambda
       in
       (lambda1, Jumps.union local_jumps total1)
@@ -2749,8 +2758,14 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
             with
             | 1, 1, [ (0, act1) ], [ (0, act2) ] ->
                 (* Typically, match on lists, will avoid isint primitive in that
-              case *)
-                Lifthenelse (arg, act2, act1)
+                   case *)
+                (* print_endline cstr.cstr_name; *)
+                let info = begin
+                  match cstr.cstr_name with
+                  | "[]" -> Match_nil
+                  | s -> Match_con(s)
+                end in
+                Lifthenelse (arg, act2, act1, info)
             | n, 0, _, [] ->
                 (* The type defines constant constructors only *)
                 call_switcher loc fail_opt arg 0 (n - 1) consts
@@ -2771,7 +2786,8 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
                     Lifthenelse
                       ( Lprim (Pisint, [ arg ], loc),
                         call_switcher loc fail_opt arg 0 (n - 1) consts,
-                        act )
+                        act,
+                        Match_none)
                 | None ->
                     (* Emit a switch, as bytecode implements this sophisticated
                       instruction *)
@@ -2780,7 +2796,8 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
                         sw_consts = consts;
                         sw_numblocks = cstr.cstr_nonconsts;
                         sw_blocks = nonconsts;
-                        sw_failaction = fail_opt
+                        sw_failaction = fail_opt;
+                        sw_names = sw_names
                       }
                     in
                     let hs, sw = share_actions_sw sw in
@@ -2823,7 +2840,7 @@ let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)
   else
     num_constr := max_int;
   let test_int_or_block arg if_int if_block =
-    Lifthenelse (Lprim (Pisint, [ arg ], loc), if_int, if_block)
+    Lifthenelse (Lprim (Pisint, [ arg ], loc), if_int, if_block, Match_none)
   in
   let sig_complete = List.length tag_lambda_list = !num_constr
   and one_action = same_actions tag_lambda_list in
@@ -2987,14 +3004,14 @@ let rec approx_present v = function
 
 let rec lower_bind v arg lam =
   match lam with
-  | Lifthenelse (cond, ifso, ifnot) -> (
+  | Lifthenelse (cond, ifso, ifnot, _) -> (
       let pcond = approx_present v cond
       and pso = approx_present v ifso
       and pnot = approx_present v ifnot in
       match (pcond, pso, pnot) with
       | false, false, false -> lam
-      | false, true, false -> Lifthenelse (cond, lower_bind v arg ifso, ifnot)
-      | false, false, true -> Lifthenelse (cond, ifso, lower_bind v arg ifnot)
+      | false, true, false -> Lifthenelse (cond, lower_bind v arg ifso, ifnot, Match_none)
+      | false, false, true -> Lifthenelse (cond, ifso, lower_bind v arg ifnot, Match_none)
       | _, _, _ -> bind Alias v arg lam
     )
   | Lswitch (ls, ({ sw_consts = [ (i, act) ]; sw_blocks = [] } as sw), loc)
@@ -3090,6 +3107,9 @@ let arg_to_var arg cls =
    Output: a lambda term, a jump summary {..., exit number -> context, .. }
 *)
 
+let names_from_construct_pattern : (pattern -> switch_names option) ref =
+  ref (fun _ -> None)
+
 let rec compile_match repr partial ctx (m : pattern_matching) =
   match m with
   | { cases = []; args = [] } -> comp_exit ctx m
@@ -3150,7 +3170,8 @@ and do_compile_matching repr partial ctx pmh =
             *)
             assert false
       in
-      let pat = what_is_cases pm.cases in
+      let pat : Typedtree.pattern = what_is_cases pm.cases in
+
       match pat.pat_desc with
       | Tpat_any ->
           compile_no_test divide_var Context.rshift repr partial ctx pm
@@ -3169,10 +3190,11 @@ and do_compile_matching repr partial ctx pmh =
             (combine_constant pat.pat_loc arg cst partial)
             ctx pm
       | Tpat_construct (_, cstr, _) ->
+          let sw_names = !names_from_construct_pattern pat in
           compile_test
             (compile_match repr partial)
             partial divide_constructor
-            (combine_constructor pat.pat_loc arg pat cstr partial)
+            (combine_constructor sw_names pat.pat_loc arg pat cstr partial)
             ctx pm
       | Tpat_array _ ->
           let kind = Typeopt.array_pattern_kind pat in
@@ -3421,8 +3443,8 @@ let simple_for_let loc param pat body =
 let rec map_return f = function
   | Llet (str, k, id, l1, l2) -> Llet (str, k, id, l1, map_return f l2)
   | Lletrec (l1, l2) -> Lletrec (l1, map_return f l2)
-  | Lifthenelse (lcond, lthen, lelse) ->
-      Lifthenelse (lcond, map_return f lthen, map_return f lelse)
+  | Lifthenelse (lcond, lthen, lelse, info) ->
+      Lifthenelse (lcond, map_return f lthen, map_return f lelse, info)
   | Lsequence (l1, l2) -> Lsequence (l1, map_return f l2)
   | Levent (l, ev) -> Levent (map_return f l, ev)
   | Ltrywith (l1, id, l2) -> Ltrywith (map_return f l1, id, map_return f l2)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1988,7 +1988,7 @@ let make_record_matching env loc all_labels def = function
             match lbl.lbl_repres with
             | Record_regular
             | Record_inlined _ ->
-                Lprim (Pfield (lbl.lbl_pos, ptr, lbl.lbl_mut, Fnone), [ arg ], loc)
+                Lprim (Pfield (lbl.lbl_pos, ptr, lbl.lbl_mut, Frecord lbl.lbl_name), [ arg ], loc)
             | Record_unboxed _ -> arg
             | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [ arg ], loc)
             | Record_extension _ ->
@@ -3004,14 +3004,14 @@ let rec approx_present v = function
 
 let rec lower_bind v arg lam =
   match lam with
-  | Lifthenelse (cond, ifso, ifnot, _) -> (
+  | Lifthenelse (cond, ifso, ifnot, info) -> (
       let pcond = approx_present v cond
       and pso = approx_present v ifso
       and pnot = approx_present v ifnot in
       match (pcond, pso, pnot) with
       | false, false, false -> lam
-      | false, true, false -> Lifthenelse (cond, lower_bind v arg ifso, ifnot, Match_none)
-      | false, false, true -> Lifthenelse (cond, ifso, lower_bind v arg ifnot, Match_none)
+      | false, true, false -> Lifthenelse (cond, lower_bind v arg ifso, ifnot, info)
+      | false, false, true -> Lifthenelse (cond, ifso, lower_bind v arg ifnot, info)
       | _, _, _ -> bind Alias v arg lam
     )
   | Lswitch (ls, ({ sw_consts = [ (i, act) ]; sw_blocks = [] } as sw), loc)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3347,7 +3347,7 @@ let partial_function loc () =
                      [ Const_base (Const_string (fname, None));
                        Const_base (Const_int line);
                        Const_base (Const_int char)
-                     ] ))
+                     ], Tag_none ))
             ],
             loc )
       ],
@@ -3452,7 +3452,7 @@ let assign_pat opt nraise catch_ids loc pat lam =
     | Tpat_tuple patl, Lprim (Pmakeblock _, lams, _) ->
         opt := true;
         List.fold_left2 collect acc patl lams
-    | Tpat_tuple patl, Lconst (Const_block (_, scl)) ->
+    | Tpat_tuple patl, Lconst (Const_block (_, scl, Tag_none)) ->
         opt := true;
         let collect_const acc pat sc = collect acc pat (Lconst sc) in
         List.fold_left2 collect_const acc patl scl

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3361,7 +3361,7 @@ let partial_function loc () =
   Lprim
     ( Praise Raise_regular,
       [ Lprim
-          ( Pmakeblock (0, Immutable, None),
+          ( Pmakeblock (0, Immutable, None, Tag_none),
             [ slot;
               Lconst
                 (Const_block
@@ -3609,7 +3609,7 @@ let do_for_multiple_match loc paraml pat_act_list partial =
     ( raise_num,
       { cases = List.map (fun (pat, act) -> ([ pat ], act)) pat_act_list;
         args =
-          [ (Lprim (Pmakeblock (0, Immutable, None), paraml, loc), Strict) ];
+          [ (Lprim (Pmakeblock (0, Immutable, None, Tag_none), paraml, loc), Strict) ];
         default
       } )
   in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1534,7 +1534,7 @@ let make_field_args loc binding_kind arg first_pos last_pos argl =
     if pos > last_pos then
       argl
     else
-      (Lprim (Pfield(pos, Pointer, Immutable), [ arg ], loc),
+      (Lprim (Pfield(pos, Pointer, Immutable, Fnone), [ arg ], loc),
           binding_kind) :: make_args (pos + 1)
   in
   make_args first_pos
@@ -1679,7 +1679,7 @@ let make_variant_matching_nonconst p lab def ctx = function
       and ctx = Context.specialize p ctx in
       { pm =
           { cases = [];
-            args = (Lprim (Pfield(1, Pointer, Immutable), [ arg ], p.pat_loc),
+            args = (Lprim (Pfield(1, Pointer, Immutable, Fnone), [ arg ], p.pat_loc),
                   Alias) :: argl;
             default = def
           };
@@ -1810,7 +1810,7 @@ let inline_lazy_force_cond arg loc =
           Lifthenelse
             ( (* if (tag == Obj.forward_tag) then varg.(0) else ... *)
               test_tag Obj.forward_tag,
-              Lprim (Pfield (0, Pointer, Mutable), [ varg ], loc),
+              Lprim (Pfield (0, Pointer, Mutable, Fnone), [ varg ], loc),
               Lifthenelse
                 (
                   (* ... if tag == Obj.lazy_tag || tag == Obj.forcing_tag then
@@ -1849,7 +1849,7 @@ let inline_lazy_force_switch arg loc =
                 sw_numblocks = 256;
                 (* PR#6033 - tag ranges from 0 to 255 *)
                 sw_blocks =
-                  [ (Obj.forward_tag, Lprim (Pfield(0, Pointer, Mutable),
+                  [ (Obj.forward_tag, Lprim (Pfield(0, Pointer, Mutable, Fnone),
                                              [ varg ], loc));
 
                     (Obj.lazy_tag,
@@ -1933,7 +1933,7 @@ let make_tuple_matching loc arity def = function
         if pos >= arity then
           argl
         else
-          (Lprim (Pfield (pos, Pointer, Immutable), [ arg ], loc), Alias)
+          (Lprim (Pfield (pos, Pointer, Immutable, Fnone), [ arg ], loc), Alias)
           :: make_args (pos + 1)
       in
       { cases = [];
@@ -1985,11 +1985,11 @@ let make_record_matching env loc all_labels def = function
             match lbl.lbl_repres with
             | Record_regular
             | Record_inlined _ ->
-                Lprim (Pfield (lbl.lbl_pos, ptr, lbl.lbl_mut), [ arg ], loc)
+                Lprim (Pfield (lbl.lbl_pos, ptr, lbl.lbl_mut, Fnone), [ arg ], loc)
             | Record_unboxed _ -> arg
             | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [ arg ], loc)
             | Record_extension _ ->
-                Lprim (Pfield (lbl.lbl_pos + 1, ptr, lbl.lbl_mut), [ arg ], loc)
+                Lprim (Pfield (lbl.lbl_pos + 1, ptr, lbl.lbl_mut, Fnone), [ arg ], loc)
           in
           let str =
             match lbl.lbl_mut with
@@ -2718,7 +2718,7 @@ let combine_constructor loc arg ex_pat cstr partial ctx def
                   nonconsts default
               in
               Llet (Alias, Pgenval, tag,
-                    Lprim (Pfield (0, Pointer, Immutable), [ arg ], loc), tests)
+                    Lprim (Pfield (0, Pointer, Immutable, Fnone), [ arg ], loc), tests)
         in
         List.fold_right
           (fun (path, act) rem ->
@@ -2804,7 +2804,7 @@ let call_switcher_variant_constr loc fail arg int_lambda_list =
     ( Alias,
       Pgenval,
       v,
-      Lprim (Pfield (0, Pointer, Immutable), [ arg ], loc),
+      Lprim (Pfield (0, Pointer, Immutable, Fnone), [ arg ], loc),
       call_switcher loc fail (Lvar v) min_int max_int int_lambda_list )
 
 let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)

--- a/lambda/matching.mli
+++ b/lambda/matching.mli
@@ -46,3 +46,5 @@ val expand_stringswitch:
     Location.t -> lambda -> (string * lambda) list -> lambda option -> lambda
 
 val inline_lazy_force : lambda -> Location.t -> lambda
+
+val names_from_construct_pattern : (pattern -> switch_names option) ref

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -26,7 +26,7 @@ let print_tag_info = function
   | Tag_tuple -> ":tuple"
 
 let print_pointer_info = function
-  | Ptr_none -> ""
+  | Ptr_none -> ":(noinfo)"
   | Ptr_bool -> ":bool"
   | Ptr_nil -> ":nil"
   | Ptr_unit -> ":unit"

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -30,9 +30,9 @@ let rec struct_const ppf = function
   | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n
   | Const_base(Const_nativeint n) -> fprintf ppf "%nin" n
   | Const_pointer n -> fprintf ppf "%ia" n
-  | Const_block(tag, []) ->
+  | Const_block(tag, [], _) ->
       fprintf ppf "[%i]" tag
-  | Const_block(tag, sc1::scl) ->
+  | Const_block(tag, sc1::scl, _) ->
       let sconsts ppf scl =
         List.iter (fun sc -> fprintf ppf "@ %a" struct_const sc) scl in
       fprintf ppf "@[<1>[%i:@ @[%a%a@]]@]" tag struct_const sc1 sconsts scl

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -169,10 +169,12 @@ let primitive ppf = function
   | Pdirapply -> fprintf ppf "dirapply"
   | Pgetglobal id -> fprintf ppf "global %a" Ident.print id
   | Psetglobal id -> fprintf ppf "setglobal %a" Ident.print id
-  | Pmakeblock(tag, Immutable, shape) ->
-      fprintf ppf "makeblock %i%a" tag block_shape shape
-  | Pmakeblock(tag, Mutable, shape) ->
-      fprintf ppf "makemutable %i%a" tag block_shape shape
+  | Pmakeblock(tag, Immutable, shape, info) ->
+      fprintf ppf "makeblock %i%s%a" tag (print_tag_info info)
+        block_shape shape
+  | Pmakeblock(tag, Mutable, shape, info) ->
+      fprintf ppf "makemutable %i%s%a" tag (print_tag_info info)
+        block_shape shape
   | Pfield(n, ptr, mut, finfo) ->
       let print_field = function
         | Fnone -> " "

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -19,6 +19,18 @@ open Primitive
 open Types
 open Lambda
 
+let print_tag_info = function
+  | Tag_none -> ""
+  | Tag_record -> ":record"
+  | Tag_con s -> sprintf ":con'%s'" s
+  | Tag_tuple -> ":tuple"
+
+let print_pointer_info = function
+  | Ptr_none -> ""
+  | Ptr_bool -> ":bool"
+  | Ptr_nil -> ":nil"
+  | Ptr_unit -> ":unit"
+  | Ptr_con(s) -> sprintf ":%s" s
 
 let rec struct_const ppf = function
   | Const_base(Const_int n) -> fprintf ppf "%i" n
@@ -29,13 +41,14 @@ let rec struct_const ppf = function
   | Const_base(Const_int32 n) -> fprintf ppf "%lil" n
   | Const_base(Const_int64 n) -> fprintf ppf "%LiL" n
   | Const_base(Const_nativeint n) -> fprintf ppf "%nin" n
-  | Const_pointer n -> fprintf ppf "%ia" n
-  | Const_block(tag, [], _) ->
-      fprintf ppf "[%i]" tag
-  | Const_block(tag, sc1::scl, _) ->
+  | Const_pointer(n, pinfo) -> fprintf ppf "%ia%s" n
+                                 (print_pointer_info pinfo)
+  | Const_block(tag, [], tinfo) ->
+      fprintf ppf "[%i%s]" tag (print_tag_info tinfo)
+  | Const_block(tag, sc1::scl, tinfo) ->
       let sconsts ppf scl =
         List.iter (fun sc -> fprintf ppf "@ %a" struct_const sc) scl in
-      fprintf ppf "@[<1>[%i:@ @[%a%a@]]@]" tag struct_const sc1 sconsts scl
+      fprintf ppf "@[<1>[%i%s:@ @[%a%a@]]@]" tag (print_tag_info tinfo) struct_const sc1 sconsts scl
   | Const_float_array [] ->
       fprintf ppf "[| |]"
   | Const_float_array (f1 :: fl) ->
@@ -160,14 +173,23 @@ let primitive ppf = function
       fprintf ppf "makeblock %i%a" tag block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield(n, ptr, mut, _) ->
+  | Pfield(n, ptr, mut, finfo) ->
+      let print_field = function
+        | Fnone -> " "
+        | Fmodule s -> sprintf ":module(%s) " s
+        | Frecord s -> sprintf ":record(%s) " s
+        | Frecord_inline s -> sprintf ":record_inline(%s) " s
+        | Fcon s -> sprintf ":con'%s'" s
+        | Ftuple -> ":tuple "
+        | Fcons -> ":cons"
+      in
       let instr =
         match ptr, mut with
-        | Immediate, _ -> "field_int "
-        | Pointer, Mutable -> "field_mut "
-        | Pointer, Immutable -> "field_imm "
+        | Immediate, _ -> "field_int"
+        | Pointer, Mutable -> "field_mut"
+        | Pointer, Immutable -> "field_imm"
       in
-      fprintf ppf "%s%i" instr n
+      fprintf ppf "%s%s%i" instr (print_field finfo) n
   | Pfield_computed -> fprintf ppf "field_computed"
   | Psetfield(n, ptr, init) ->
       let instr =
@@ -629,8 +651,14 @@ let rec lam ppf = function
   | Ltrywith(lbody, param, lhandler) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -1>with %a@ %a)@]"
         lam lbody Ident.print param lam lhandler
-  | Lifthenelse(lcond, lif, lelse) ->
-      fprintf ppf "@[<2>(if@ %a@ %a@ %a)@]" lam lcond lam lif lam lelse
+  | Lifthenelse(lcond, lif, lelse, info) ->
+      let print_match_info = function
+        | Match_none -> ""
+        | Match_nil -> ":[]"
+        | Match_con(s) -> sprintf ":%s" s
+      in
+      fprintf ppf "@[<2>(if@ %a%s@ %a@ %a)@]" lam lcond (print_match_info info)
+        lam lif lam lelse
   | Lsequence(l1, l2) ->
       fprintf ppf "@[<2>(seq@ %a@ %a)@]" lam l1 sequence l2
   | Lwhile(lcond, lbody) ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -160,7 +160,7 @@ let primitive ppf = function
       fprintf ppf "makeblock %i%a" tag block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield(n, ptr, mut) ->
+  | Pfield(n, ptr, mut, _) ->
       let instr =
         match ptr, mut with
         | Immediate, _ -> "field_int "

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -243,8 +243,8 @@ let simplify_exits lam =
         (* Simplify Obj.with_tag *)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
-         Lprim (Pmakeblock (_, mut, shape), fields, loc)] ->
-         Lprim (Pmakeblock(tag, mut, shape), fields, loc)
+         Lprim (Pmakeblock (_, mut, shape, tag_info), fields, loc)] ->
+         Lprim (Pmakeblock(tag, mut, shape, tag_info), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
          Lconst (Const_block (_, fields, Tag_none))] ->
@@ -531,7 +531,7 @@ let simplify_lets lam =
       Hashtbl.add subst v (simplif (Lvar w));
       simplif l2
   | Llet(Strict, kind, v,
-         Lprim(Pmakeblock(0, Mutable, kind_ref) as prim, [linit], loc), lbody)
+         Lprim(Pmakeblock(0, Mutable, kind_ref, _) as prim, [linit], loc), lbody)
     when optimize ->
       let slinit = simplif linit in
       let slbody = simplif lbody in

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -245,8 +245,8 @@ let simplify_exits lam =
          Lprim (Pmakeblock(tag, mut, shape), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
-         Lconst (Const_block (_, fields))] ->
-         Lconst (Const_block (tag, fields))
+         Lconst (Const_block (_, fields, Tag_none))] ->
+          Lconst (Const_block (tag, fields, Tag_none))
 
       | _ -> Lprim(p, ll, loc)
      end
@@ -341,7 +341,7 @@ let exact_application {kind; params; _} args =
           if List.length params <> List.length tupled_args
           then None
           else Some tupled_args
-      | [Lconst(Const_block (_, const_args))] ->
+      | [Lconst(Const_block (_, const_args, Tag_none))] ->
           if List.length params <> List.length const_args
           then None
           else Some (List.map (fun cst -> Lconst cst) const_args)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -39,7 +39,7 @@ let rec eliminate_ref id = function
   | Lletrec(idel, e2) ->
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
-  | Lprim(Pfield (0, _, _), [Lvar v], _) when Ident.same v id ->
+  | Lprim(Pfield (0, _, _, _), [Lvar v], _) when Ident.same v id ->
       Lvar id
   | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
       Lassign(id, eliminate_ref id e)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -56,7 +56,8 @@ let rec eliminate_ref id = function
          sw_blocks =
             List.map (fun (n, e) -> (n, eliminate_ref id e)) sw.sw_blocks;
          sw_failaction =
-            Option.map (eliminate_ref id) sw.sw_failaction; },
+           Option.map (eliminate_ref id) sw.sw_failaction;
+         sw_names = None },
         loc)
   | Lstringswitch(e, sw, default, loc) ->
       Lstringswitch
@@ -69,10 +70,11 @@ let rec eliminate_ref id = function
       Lstaticcatch(eliminate_ref id e1, i, eliminate_ref id e2)
   | Ltrywith(e1, v, e2) ->
       Ltrywith(eliminate_ref id e1, v, eliminate_ref id e2)
-  | Lifthenelse(e1, e2, e3) ->
+  | Lifthenelse(e1, e2, e3, info) ->
       Lifthenelse(eliminate_ref id e1,
                   eliminate_ref id e2,
-                  eliminate_ref id e3)
+                  eliminate_ref id e3,
+                  info)
   | Lsequence(e1, e2) ->
       Lsequence(eliminate_ref id e1, eliminate_ref id e2)
   | Lwhile(e1, e2) ->
@@ -156,7 +158,7 @@ let simplify_exits lam =
       if (get_exit i).count > 0 then
         count l2
   | Ltrywith(l1, _v, l2) -> incr try_depth; count l1; decr try_depth; count l2
-  | Lifthenelse(l1, l2, l3) -> count l1; count l2; count l3
+  | Lifthenelse(l1, l2, l3, _) -> count l1; count l2; count l3
   | Lsequence(l1, l2) -> count l1; count l2
   | Lwhile(l1, l2) -> count l1; count l2
   | Lfor(_, l1, l2, _dir, l3) -> count l1; count l2; count l3
@@ -308,7 +310,8 @@ let simplify_exits lam =
       let l1 = simplif l1 in
       decr try_depth;
       Ltrywith(l1, v, simplif l2)
-  | Lifthenelse(l1, l2, l3) -> Lifthenelse(simplif l1, simplif l2, simplif l3)
+  | Lifthenelse(l1, l2, l3, info) ->
+      Lifthenelse(simplif l1, simplif l2, simplif l3, info)
   | Lsequence(l1, l2) -> Lsequence(simplif l1, simplif l2)
   | Lwhile(l1, l2) -> Lwhile(simplif l1, simplif l2)
   | Lfor(v, l1, l2, dir, l3) ->
@@ -447,7 +450,7 @@ let simplify_lets lam =
   | Lstaticraise (_i,ls) -> List.iter (count bv) ls
   | Lstaticcatch(l1, _, l2) -> count bv l1; count bv l2
   | Ltrywith(l1, _v, l2) -> count bv l1; count bv l2
-  | Lifthenelse(l1, l2, l3) -> count bv l1; count bv l2; count bv l3
+  | Lifthenelse(l1, l2, l3, _) -> count bv l1; count bv l2; count bv l3
   | Lsequence(l1, l2) -> count bv l1; count bv l2
   | Lwhile(l1, l2) -> count Ident.Map.empty l1; count Ident.Map.empty l2
   | Lfor(_, l1, l2, _dir, l3) ->
@@ -576,7 +579,8 @@ let simplify_lets lam =
   | Lstaticcatch(l1, (i,args), l2) ->
       Lstaticcatch (simplif l1, (i,args), simplif l2)
   | Ltrywith(l1, v, l2) -> Ltrywith(simplif l1, v, simplif l2)
-  | Lifthenelse(l1, l2, l3) -> Lifthenelse(simplif l1, simplif l2, simplif l3)
+  | Lifthenelse(l1, l2, l3, info) ->
+      Lifthenelse(simplif l1, simplif l2, simplif l3, info)
   | Lsequence(Lifused(v, l1), l2) ->
       if count_var v > 0
       then Lsequence(simplif l1, simplif l2)
@@ -655,7 +659,7 @@ let rec emit_tail_infos is_tail lambda =
   | Ltrywith (body, _, handler) ->
       emit_tail_infos false body;
       emit_tail_infos is_tail handler
-  | Lifthenelse (cond, ifso, ifno) ->
+  | Lifthenelse (cond, ifso, ifno, _) ->
       emit_tail_infos false cond;
       emit_tail_infos is_tail ifso;
       emit_tail_infos is_tail ifno
@@ -696,7 +700,7 @@ and list_emit_tail_infos is_tail =
 
 let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body ~attr ~loc =
   let rec aux map = function
-    | Llet(Strict, k, id, (Lifthenelse(Lvar optparam, _, _) as def), rest) when
+    | Llet(Strict, k, id, (Lifthenelse(Lvar optparam, _, _, _) as def), rest) when
         Ident.name optparam = "*opt*" && List.mem_assoc optparam params
           && not (List.mem_assoc optparam map)
       ->

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -64,7 +64,7 @@ let lfield v i = Lprim(Pfield (i, Pointer, Mutable, Fnone),
 let transl_label l = share (Const_immstring l)
 
 let transl_meth_list lst =
-  if lst = [] then Lconst (Const_pointer 0) else
+  if lst = [] then Lconst (Const_pointer (0, Ptr_none)) else
   share (Const_block
            (0, List.map (fun lab -> Const_immstring lab) lst, Tag_none))
 
@@ -372,7 +372,7 @@ let rec build_class_init cla cstr super inh_init cl_init msubst top cl =
            Llet (Strict, Pgenval, inh,
                  mkappl(oo_prim "inherits", narrow_args @
                         [path_lam;
-                         Lconst(Const_pointer(if top then 1 else 0))]),
+                         Lconst(Const_pointer((if top then 1 else 0), Ptr_none))]),
                  Llet(StrictOpt, Pgenval, obj_init, lfield inh 0, cl_init)))
       | _ ->
           let core cl_init =
@@ -532,7 +532,7 @@ let rec builtin_meths self env env2 body =
     | Lprim(Parrayrefu _, [Lvar s; Lvar n], _) when List.mem s self ->
         "var", [Lvar n]
     | Lprim(Pfield(n, _, _, _), [Lvar e], _) when Ident.same e env ->
-        "env", [Lvar env2; Lconst(Const_pointer n)]
+        "env", [Lvar env2; Lconst(Const_pointer (n, Ptr_none))]
     | Lsend(Self, met, Lvar s, [], _) when List.mem s self ->
         "meth", [met]
     | _ -> raise Not_found
@@ -603,7 +603,7 @@ module M = struct
     | "send_env"   -> SendEnv
     | "send_meth"  -> SendMeth
     | _ -> assert false
-    in Lconst(Const_pointer(Obj.magic tag)) :: args
+    in Lconst(Const_pointer(Obj.magic tag, Ptr_none)) :: args
 end
 open M
 
@@ -900,7 +900,7 @@ let transl_class ids cl_id pub_meths cl vflag =
          so that the program's behaviour does not change between runs *)
       lupdate_cache
     else
-      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache) in
+      Lifthenelse(lfield cached 0, lambda_unit, lupdate_cache, Match_none) in
   llets (
   lcache (
   Lsequence(lcheck_cache,

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -58,7 +58,7 @@ let mkappl (func, args) =
 let lsequence l1 l2 =
   if l2 = lambda_unit then l1 else Lsequence(l1, l2)
 
-let lfield v i = Lprim(Pfield (i, Pointer, Mutable),
+let lfield v i = Lprim(Pfield (i, Pointer, Mutable, Fnone),
                        [Lvar v], Location.none)
 
 let transl_label l = share (Const_immstring l)
@@ -130,7 +130,7 @@ let rec build_object_init cl_table obj params inh_init obj_init cl =
       let env =
         match envs with None -> []
         | Some envs ->
-            [Lprim(Pfield (List.length inh_init + 1, Pointer, Mutable),
+            [Lprim(Pfield (List.length inh_init + 1, Pointer, Mutable, Fnone),
                    [Lvar envs],
                    Location.none)]
       in
@@ -269,9 +269,9 @@ let rec build_class_init cla cstr super inh_init cl_init msubst top cl =
       | (_, path_lam, obj_init)::inh_init ->
           (inh_init,
            Llet (Strict, Pgenval, obj_init,
-                 mkappl(Lprim(Pfield (1, Pointer, Mutable),
+                 mkappl(Lprim(Pfield (1, Pointer, Mutable, Fnone),
                               [path_lam], Location.none), Lvar cla ::
-                        if top then [Lprim(Pfield (3, Pointer, Mutable),
+                        if top then [Lprim(Pfield (3, Pointer, Mutable, Fnone),
                                      [path_lam], Location.none)]
                         else []),
                  bind_super cla super cl_init))
@@ -531,7 +531,7 @@ let rec builtin_meths self env env2 body =
     | p when const_path p -> "const", [p]
     | Lprim(Parrayrefu _, [Lvar s; Lvar n], _) when List.mem s self ->
         "var", [Lvar n]
-    | Lprim(Pfield(n, _, _), [Lvar e], _) when Ident.same e env ->
+    | Lprim(Pfield(n, _, _, _), [Lvar e], _) when Ident.same e env ->
         "env", [Lvar env2; Lconst(Const_pointer n)]
     | Lsend(Self, met, Lvar s, [], _) when List.mem s self ->
         "meth", [met]
@@ -827,7 +827,7 @@ let transl_class ids cl_id pub_meths cl vflag =
   and linh_envs =
     List.map
       (fun (_, path_lam, _) ->
-        Lprim(Pfield (3, Pointer, Mutable), [path_lam], Location.none))
+        Lprim(Pfield (3, Pointer, Mutable, Fnone), [path_lam], Location.none))
       (List.rev inh_init)
   in
   let make_envs lam =
@@ -848,7 +848,7 @@ let transl_class ids cl_id pub_meths cl vflag =
   let inh_keys =
     List.map
       (fun (_, path_lam, _) ->
-        Lprim(Pfield (1, Pointer, Mutable), [path_lam], Location.none))
+        Lprim(Pfield (1, Pointer, Mutable, Fnone), [path_lam], Location.none))
       inh_paths
   in
   let lclass lam =

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -245,7 +245,7 @@ let output_methods tbl methods lam =
       lsequence (mkappl(oo_prim "set_method", [Lvar tbl; lab; code])) lam
   | _ ->
       lsequence (mkappl(oo_prim "set_methods",
-                        [Lvar tbl; Lprim(Pmakeblock(0,Immutable,None),
+                        [Lvar tbl; Lprim(Pmakeblock(0,Immutable,None,Tag_none),
                                          methods, Location.none)]))
         lam
 
@@ -493,7 +493,7 @@ let transl_class_rebind cl vf =
     Strict, Pgenval, new_init, lfunction [obj_init, Pgenval] obj_init',
     Llet(
     Alias, Pgenval, cla, path_lam,
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           [mkappl(Lvar new_init, [lfield cla 0]);
            lfunction [table, Pgenval]
              (Llet(Strict, Pgenval, env_init,
@@ -789,12 +789,12 @@ let transl_class ids cl_id pub_meths cl vflag =
       Strict, Pgenval, env_init, mkappl (Lvar class_init, [Lvar table]),
       Lsequence(
       mkappl (oo_prim "init_class", [Lvar table]),
-      Lprim(Pmakeblock(0, Immutable, None),
+      Lprim(Pmakeblock(0, Immutable, None, Tag_none),
             [mkappl (Lvar env_init, [lambda_unit]);
              Lvar class_init; Lvar env_init; lambda_unit],
             Location.none))))
   and lbody_virt lenvs =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           [lambda_unit; Lfunction{kind = Curried;
                                   attr = default_function_attribute;
                                   loc = Location.none;
@@ -817,11 +817,11 @@ let transl_class ids cl_id pub_meths cl vflag =
   let lenv =
     let menv =
       if !new_ids_meths = [] then lambda_unit else
-      Lprim(Pmakeblock(0, Immutable, None),
+      Lprim(Pmakeblock(0, Immutable, None, Tag_none),
             List.map (fun id -> Lvar id) !new_ids_meths,
             Location.none) in
     if !new_ids_init = [] then menv else
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           menv :: List.map (fun id -> Lvar id) !new_ids_init,
           Location.none)
   and linh_envs =
@@ -833,7 +833,7 @@ let transl_class ids cl_id pub_meths cl vflag =
   let make_envs lam =
     Llet(StrictOpt, Pgenval, envs,
          (if linh_envs = [] then lenv else
-         Lprim(Pmakeblock(0, Immutable, None),
+         Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                lenv :: linh_envs, Location.none)),
          lam)
   and def_ids cla lam =
@@ -862,7 +862,7 @@ let transl_class ids cl_id pub_meths cl vflag =
     if inh_keys = [] then Llet(Alias, Pgenval, cached, Lvar tables, lam) else
     Llet(Strict, Pgenval, cached,
          mkappl (oo_prim "lookup_tables",
-                [Lvar tables; Lprim(Pmakeblock(0, Immutable, None),
+                [Lvar tables; Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                                     inh_keys, Location.none)]),
          lam)
   and lset cached i lam =
@@ -906,7 +906,7 @@ let transl_class ids cl_id pub_meths cl vflag =
   Lsequence(lcheck_cache,
   make_envs (
   if ids = [] then mkappl (lfield cached 0, [lenvs]) else
-  Lprim(Pmakeblock(0, Immutable, None),
+  Lprim(Pmakeblock(0, Immutable, None, Tag_none),
         (if concrete then
           [mkappl (lfield cached 0, [lenvs]);
            lfield cached 1;

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -66,7 +66,7 @@ let transl_label l = share (Const_immstring l)
 let transl_meth_list lst =
   if lst = [] then Lconst (Const_pointer 0) else
   share (Const_block
-            (0, List.map (fun lab -> Const_immstring lab) lst))
+           (0, List.map (fun lab -> Const_immstring lab) lst, Tag_none))
 
 let set_inst_var obj id expr =
   Lprim(Psetfield_computed (Typeopt.maybe_pointer expr, Assignment),

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -179,7 +179,8 @@ let assert_failed exp =
            Lconst(Const_block(0,
               [Const_base(Const_string (fname, None));
                Const_base(Const_int line);
-               Const_base(Const_int char)]))], exp.exp_loc))], exp.exp_loc)
+               Const_base(Const_int char)],
+                              Tag_none))], exp.exp_loc))], exp.exp_loc)
 ;;
 
 let rec cut n l =
@@ -293,7 +294,7 @@ and transl_exp0 e =
   | Texp_tuple el ->
       let ll, shape = transl_list_with_shape el in
       begin try
-        Lconst(Const_block(0, List.map extract_constant ll))
+        Lconst(Const_block(0, List.map extract_constant ll, Tag_none))
       with Not_constant ->
         Lprim(Pmakeblock(0, Immutable, Some shape), ll, e.exp_loc)
       end
@@ -309,7 +310,7 @@ and transl_exp0 e =
           (match ll with [v] -> v | _ -> assert false)
       | Cstr_block n ->
           begin try
-            Lconst(Const_block(n, List.map extract_constant ll))
+            Lconst(Const_block(n, List.map extract_constant ll, Tag_none))
           with Not_constant ->
             Lprim(Pmakeblock(n, Immutable, Some shape), ll, e.exp_loc)
           end
@@ -330,7 +331,8 @@ and transl_exp0 e =
           let lam = transl_exp arg in
           try
             Lconst(Const_block(0, [Const_base(Const_int tag);
-                                   extract_constant lam]))
+                                   extract_constant lam],
+                              Tag_none))
           with Not_constant ->
             Lprim(Pmakeblock(0, Immutable, None),
                   [Lconst(Const_base(Const_int tag)); lam], e.exp_loc)
@@ -396,7 +398,7 @@ and transl_exp0 e =
             let imm_array =
               match kind with
               | Paddrarray | Pintarray ->
-                  Lconst(Const_block(0, cl))
+                  Lconst(Const_block(0, cl, Tag_none))
               | Pfloatarray ->
                   Lconst(Const_float_array(List.map extract_float cl))
               | Pgenarray ->
@@ -841,8 +843,8 @@ and transl_record loc env fields repres opt_init_expr =
         if mut = Mutable then raise Not_constant;
         let cl = List.map extract_constant ll in
         match repres with
-        | Record_regular -> Lconst(Const_block(0, cl))
-        | Record_inlined tag -> Lconst(Const_block(tag, cl))
+        | Record_regular -> Lconst(Const_block(0, cl, Tag_record))
+        | Record_inlined tag -> Lconst(Const_block(tag, cl, Tag_none))
         | Record_unboxed _ -> Lconst(match cl with [v] -> v | _ -> assert false)
         | Record_float ->
             Lconst(Const_float_array(List.map extract_float cl))

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -216,7 +216,8 @@ let undefined_location loc =
   Lconst(Const_block(0,
                      [Const_base(Const_string (fname, None));
                       Const_base(Const_int line);
-                      Const_base(Const_int char)]))
+                      Const_base(Const_int char)],
+                     Tag_none))
 
 exception Initialization_failure of unsafe_info
 
@@ -228,7 +229,7 @@ let init_shape id modl =
         raise (Initialization_failure
                 (Unsafe {reason=Unsafe_module_binding;loc;subid}))
     | Mty_signature sg ->
-        Const_block(0, [Const_block(0, init_shape_struct env sg)])
+        Const_block(0, [Const_block(0, init_shape_struct env sg, Tag_none)], Tag_none)
     | Mty_functor _ ->
         (* can we do better? *)
         raise (Initialization_failure

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -84,7 +84,7 @@ let rec apply_coercion loc strict restr arg =
           else Lprim(Pfield (pos, Pointer, Mutable, Fnone), [Lvar id], loc)
         in
         let lam =
-          Lprim(Pmakeblock(0, Immutable, None),
+          Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                 List.map (apply_coercion_field loc get_field) pos_cc_list,
                 loc)
         in
@@ -531,7 +531,7 @@ and transl_structure loc fields cc rootpath final_env = function
       let body, size =
         match cc with
           Tcoerce_none ->
-            Lprim(Pmakeblock(0, Immutable, None),
+            Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                   List.map (fun id -> Lvar id) (List.rev fields), loc),
               List.length fields
         | Tcoerce_structure(pos_cc_list, id_pos_list) ->
@@ -547,7 +547,7 @@ and transl_structure loc fields cc rootpath final_env = function
             in
             let ids = List.fold_right Ident.Set.add fields Ident.Set.empty in
             let lam =
-              Lprim(Pmakeblock(0, Immutable, None),
+              Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                   List.map
                     (fun (pos, cc) ->
                       match cc with
@@ -1029,7 +1029,7 @@ let transl_store_structure glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                                     List.map (fun id -> Lvar id)
                                       (defined_idents str.str_items), loc)),
                            Lsequence(store_ident loc id,
@@ -1058,7 +1058,7 @@ let transl_store_structure glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, None, Tag_none),
                                     List.map field map, loc)),
                            Lsequence(store_ident loc id,
                                      transl_store rootpath
@@ -1506,13 +1506,13 @@ let transl_package_flambda component_names coercion =
   in
   size,
   apply_coercion Location.none Strict coercion
-    (Lprim(Pmakeblock(0, Immutable, None),
+    (Lprim(Pmakeblock(0, Immutable, None, Tag_none),
            List.map get_component component_names,
            Location.none))
 
 let transl_package component_names target_name coercion =
   let components =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Tag_none),
           List.map get_component component_names, Location.none) in
   Lprim(Psetglobal target_name,
         [apply_coercion Location.none Strict coercion components],
@@ -1550,7 +1550,7 @@ let transl_store_package component_names target_name coercion =
          0 component_names)
   | Tcoerce_structure (pos_cc_list, _id_pos_list) ->
       let components =
-        Lprim(Pmakeblock(0, Immutable, None),
+        Lprim(Pmakeblock(0, Immutable, None, Tag_none),
               List.map get_component component_names,
               Location.none)
       in

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -241,9 +241,9 @@ let init_shape id modl =
         let init_v =
           match Ctype.expand_head env ty with
             {desc = Tarrow(_,_,_,_)} ->
-              Const_pointer 0 (* camlinternalMod.Function *)
+              Const_pointer (0, Ptr_none) (* camlinternalMod.Function *)
           | {desc = Tconstr(p, _, _)} when Path.same p Predef.path_lazy_t ->
-              Const_pointer 1 (* camlinternalMod.Lazy *)
+              Const_pointer (1, Ptr_none) (* camlinternalMod.Lazy *)
           | _ ->
               let not_a_function =
                 Unsafe {reason=Unsafe_non_function; loc; subid }
@@ -269,7 +269,7 @@ let init_shape id modl =
     | Sig_modtype(id, minfo, _) :: rem ->
         init_shape_struct (Env.add_modtype id minfo env) rem
     | Sig_class _ :: rem ->
-        Const_pointer 2 (* camlinternalMod.Class *)
+        Const_pointer (2, Ptr_none) (* camlinternalMod.Class *)
         :: init_shape_struct env rem
     | Sig_class_type _ :: rem ->
         init_shape_struct env rem

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -26,7 +26,7 @@ let consts : (structured_constant, Ident.t) Hashtbl.t = Hashtbl.create 17
 
 let share c =
   match c with
-    Const_block (_n, l) when l <> [] ->
+    Const_block (_n, l, _) when l <> [] ->
       begin try
         Lvar (Hashtbl.find consts c)
       with Not_found ->

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -125,7 +125,7 @@ let transl_label_init_flambda f =
 let transl_store_label_init glob size f arg =
   assert(not Config.flambda);
   assert(!Clflags.native_code);
-  method_cache := Lprim(Pfield (size, Pointer, Mutable),
+  method_cache := Lprim(Pfield (size, Pointer, Mutable, Fnone),
                         (* XXX KC: conservative *)
                         [Lprim(Pgetglobal glob, [], Location.none)],
                         Location.none);

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -179,7 +179,7 @@ let oo_wrap env req f x =
            List.fold_left
              (fun lambda id ->
                 Llet(StrictOpt, Pgenval, id,
-                     Lprim(Pmakeblock(0, Mutable, None),
+                     Lprim(Pmakeblock(0, Mutable, None, Tag_none),
                            [lambda_unit; lambda_unit; lambda_unit],
                            Location.none),
                      lambda))

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -123,8 +123,8 @@ let primitives_table =
     "%field0", Primitive (Pfield(0, Pointer, Mutable, Fnone), 1);
     "%field1", Primitive (Pfield(1, Pointer, Mutable, Fnone), 1);
     "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
-    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
-    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
+    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None, Tag_none)), 1);
+    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None, Tag_none)), 1);
     "%raise", Raise Raise_regular;
     "%reraise", Raise Raise_reraise;
     "%raise_notrace", Raise Raise_notrace;
@@ -472,10 +472,11 @@ let specialize_primitive env ty ~has_constant_constructor prim =
       | Pbigarray_unknown, Pbigarray_unknown_layout -> None
       | _, _ -> Some (Primitive (Pbigarrayset(unsafe, n, k, l), arity))
     end
-  | Primitive (Pmakeblock(tag, mut, None), arity), fields -> begin
+  | Primitive (Pmakeblock(tag, mut, None, tag_info), arity), fields -> begin
       let shape = List.map (Typeopt.value_kind env) fields in
       let useful = List.exists (fun knd -> knd <> Pgenval) shape in
-      if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape), arity))
+      if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape, tag_info),
+                                      arity))
       else None
     end
   | Primitive (Patomic_load { immediate_or_pointer = Pointer }, arity), _ -> begin
@@ -712,7 +713,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
       lambda_of_loc kind loc
   | Loc kind, [arg] ->
       let lam = lambda_of_loc kind loc in
-      Lprim(Pmakeblock(0, Immutable, None), [lam; arg], loc)
+      Lprim(Pmakeblock(0, Immutable, None, Tag_none), [lam; arg], loc)
   | Send, [obj; meth] ->
       Lsend(Public, meth, obj, [], loc)
   | Send_self, [obj; meth] ->

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -672,7 +672,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
   | Primitive (prim, arity), args when arity = List.length args ->
       Lprim(prim, args, loc)
   | External prim, args when prim = prim_sys_argv ->
-      Lprim(Pccall prim, Lconst (Const_pointer 0) :: args, loc)
+      Lprim(Pccall prim, Lconst (Const_pointer(0, Ptr_none)) :: args, loc)
   | External prim, args ->
       Lprim(Pccall prim, args, loc)
   | Comparison(comp, knd), ([_;_] as args) ->

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -643,7 +643,7 @@ let lambda_of_loc kind loc =
           Const_base (Const_int lnum);
           Const_base (Const_int cnum);
           Const_base (Const_int enum);
-        ]))
+        ], Tag_none))
   | Loc_FILE -> Lconst (Const_immstring file)
   | Loc_MODULE ->
     let filename = Filename.basename file in

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -120,8 +120,8 @@ let primitives_table =
     "%loc_LINE", Loc Loc_LINE;
     "%loc_POS", Loc Loc_POS;
     "%loc_MODULE", Loc Loc_MODULE;
-    "%field0", Primitive (Pfield(0, Pointer, Mutable), 1);
-    "%field1", Primitive (Pfield(1, Pointer, Mutable), 1);
+    "%field0", Primitive (Pfield(0, Pointer, Mutable, Fnone), 1);
+    "%field1", Primitive (Pfield(1, Pointer, Mutable, Fnone), 1);
     "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
     "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
     "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
@@ -427,12 +427,12 @@ let specialize_primitive env ty ~has_constant_constructor prim =
       | Pointer -> None
       | Immediate -> Some (Primitive (Psetfield(n, Immediate, init), arity))
     end
-  | Primitive (Pfield (n, Pointer, mut), arity), _ ->
+  | Primitive (Pfield (n, Pointer, mut, _), arity), _ ->
       (* try strength reduction based on the *result type* *)
       let is_int = match is_function_type env ty with
         | None -> Pointer
         | Some (_p1, rhs) -> maybe_pointer_type env rhs in
-      Some (Primitive (Pfield (n, is_int, mut), arity))
+      Some (Primitive (Pfield (n, is_int, mut, Fnone), arity))
   | Primitive (Parraylength t, arity), [p] -> begin
       let array_type = glb_array_type t (array_type_kind env p) in
       if t = array_type then None

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -860,7 +860,7 @@ let rec close ({ backend; fenv; cenv } as env) lam =
         | Const_base(Const_int n) -> Uconst_int n
         | Const_base(Const_char c) -> Uconst_int (Char.code c)
         | Const_pointer n -> Uconst_ptr n
-        | Const_block (tag, fields) ->
+        | Const_block (tag, fields, _) ->
             str (Uconst_block (tag, List.map transl fields))
         | Const_float_array sl ->
             (* constant float arrays are really immutable *)

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1057,7 +1057,7 @@ let rec close ({ backend; fenv; cenv } as env) lam =
       let dbg = Debuginfo.from_location loc in
       check_constant_result (getglobal dbg id)
                             (Compilenv.global_approx id)
-  | Lprim(Pfield (n, ptr, mut), [lam], loc) ->
+  | Lprim(Pfield (n, ptr, mut, _), [lam], loc) ->
       let (ulam, approx) = close env lam in
       let dbg = Debuginfo.from_location loc in
       check_constant_result (Uprim(P.Pfield (n, ptr, mut), [ulam], dbg))

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -859,7 +859,7 @@ let rec close ({ backend; fenv; cenv } as env) lam =
       let rec transl = function
         | Const_base(Const_int n) -> Uconst_int n
         | Const_base(Const_char c) -> Uconst_int (Char.code c)
-        | Const_pointer n -> Uconst_ptr n
+        | Const_pointer(n, _) -> Uconst_ptr n
         | Const_block (tag, fields, _) ->
             str (Uconst_block (tag, List.map transl fields))
         | Const_float_array sl ->
@@ -1137,7 +1137,7 @@ let rec close ({ backend; fenv; cenv } as env) lam =
       let (ubody, _) = close env body in
       let (uhandler, _) = close env handler in
       (Utrywith(ubody, VP.create id, uhandler), Value_unknown)
-  | Lifthenelse(arg, ifso, ifnot) ->
+  | Lifthenelse(arg, ifso, ifnot, _) ->
       begin match close env arg with
         (uarg, Value_const (Uconst_ptr n)) ->
           sequence_constant_expr uarg

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -24,7 +24,7 @@ let convert_unsafety is_unsafe : Clambda_primitives.is_safe =
 
 let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
-  | Pmakeblock (tag, mutability, shape) ->
+  | Pmakeblock (tag, mutability, shape, _) ->
       Pmakeblock (tag, mutability, shape)
   | Pfield (field, imm_or_pointer, mutability, _) ->
       Pfield (field, imm_or_pointer, mutability)

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -26,7 +26,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
   | Pmakeblock (tag, mutability, shape) ->
       Pmakeblock (tag, mutability, shape)
-  | Pfield (field, imm_or_pointer, mutability) ->
+  | Pfield (field, imm_or_pointer, mutability, _) ->
       Pfield (field, imm_or_pointer, mutability)
   | Pfield_computed -> Pfield_computed
   | Psetfield (field, imm_or_pointer, init_or_assign) ->

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -137,7 +137,7 @@ let rec declare_const t (const : Lambda.structured_constant)
       Names.const_int64
   | Const_base (Const_nativeint c) ->
     register_const t (Allocated_const (Nativeint c)) Names.const_nativeint
-  | Const_pointer c -> Const (Const_pointer c), Names.const_ptr
+  | Const_pointer(c, _) -> Const (Const_pointer c), Names.const_ptr
   | Const_immstring c ->
     register_const t (Allocated_const (Immutable_string c))
       Names.const_immstring
@@ -162,9 +162,9 @@ let close_const t (const : Lambda.structured_constant)
 
 let lambda_const_bool b : Lambda.structured_constant =
   if b then
-    Const_pointer 1
+    Const_pointer(1, Ptr_none)
   else
-    Const_pointer 0
+    Const_pointer(0, Ptr_none)
 
 let lambda_const_int i : Lambda.structured_constant =
   Const_base (Const_int i)
@@ -448,7 +448,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
         | Ostype_win32 -> lambda_const_bool (String.equal Sys.os_type "Win32")
         | Ostype_cygwin -> lambda_const_bool (String.equal Sys.os_type "Cygwin")
         | Backend_type ->
-            Lambda.Const_pointer 0 (* tag 0 is the same as Native *)
+            Lambda.Const_pointer(0, Ptr_none) (* tag 0 is the same as Native *)
         end
       in
       close t env
@@ -527,7 +527,7 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
   | Ltrywith (body, id, handler) ->
     let var = Variable.create_with_same_name_as_ident id in
     Try_with (close t env body, var, close t (Env.add_var env id var) handler)
-  | Lifthenelse (cond, ifso, ifnot) ->
+  | Lifthenelse (cond, ifso, ifnot, _) ->
     let cond = close t env cond in
     let cond_var = Variable.create Names.cond in
     Flambda.create_let cond_var (Expr cond)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -145,7 +145,7 @@ let rec declare_const t (const : Lambda.structured_constant)
     register_const t
       (Allocated_const (Immutable_float_array (List.map float_of_string c)))
       Names.const_float_array
-  | Const_block (tag, consts) ->
+  | Const_block (tag, consts, _) ->
     let const : Flambda.constant_defining_value =
       Block (Tag.create_exn tag,
              List.map (fun c -> fst (declare_const t c)) consts)

--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -1,11 +1,11 @@
 (* In order to use the development compiler with opam 2.0, first create a new
    switch
 
-      opam switch create 4.10.0+multicore --empty
+      opam switch create 4.10.0+multicore+flambda --empty
 
    Initial build:
 
-      opam pin add -k path --inplace-build ocaml-variants.4.10.0+multicore .
+      opam pin add -k path --inplace-build ocaml-variants.4.10.0+multicore+flambda .
 
    This installs the compiler for the new opam switch. Subsequent builds can be
    done locally with:

--- a/ocaml-variants.opam
+++ b/ocaml-variants.opam
@@ -19,8 +19,8 @@
 *)
 
 opam-version: "2.0"
-version: "4.10.0+multicore"
-synopsis: "OCaml multicore 4.10.0"
+version: "4.10.0+multicore+flambda"
+synopsis: "OCaml multicore 4.10.0 with flambda enabled"
 depends: [
   "ocaml" {= "4.10.0" & post}
   "base-unix" {post}
@@ -31,11 +31,11 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--enable-debug-runtime"]
+  ["./configure" "--prefix=%{prefix}%" "--enable-debug-runtime" "--enable-flambda"]
   [make "-j%{jobs}%"]
 ]
 install: [make "install"]
-maintainer: "kc@kcsrk.info"
-homepage: "https://github.com/ocaml-multicore/ocaml-multicore"
-bug-reports: "https://github.com/ocaml-multicore/ocaml-multicore/issues"
+maintainer: "lingmar@kth.se"
+homepage: "https://github.com/miking-lang/ocaml-multicore"
+bug-reports: "https://github.com/miking-lang/ocaml-multicore/issues"
 authors: "Xavier Leroy and many contributors"

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -92,7 +92,7 @@ let rec print_struct_const = function
   | Const_base(Const_int32 i) -> printf "%ldl" i
   | Const_base(Const_nativeint i) -> printf "%ndn" i
   | Const_base(Const_int64 i) -> printf "%LdL" i
-  | Const_pointer n -> printf "%da" n
+  | Const_pointer(n, _) -> printf "%da" n
   | Const_block(tag, args, _) ->
       printf "<%d>" tag;
       begin match args with

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -93,7 +93,7 @@ let rec print_struct_const = function
   | Const_base(Const_nativeint i) -> printf "%ndn" i
   | Const_base(Const_int64 i) -> printf "%LdL" i
   | Const_pointer n -> printf "%da" n
-  | Const_block(tag, args) ->
+  | Const_block(tag, args, _) ->
       printf "<%d>" tag;
       begin match args with
         [] -> ()


### PR DESCRIPTION
This PR
* Updates `ocaml-variants.opam` to include `flambda`
* Migrates my changes from `gc_parallel_minor` branch (needed for `ocaml2mcore` compiler).

See the file `ocaml-variants.opam` for how to set up a multicore opam switch with `flambda` enabled. The switch works to build Miking, but ironically the parallel programming feature does not work because it's not possible to install the `domainslib` package on this switch (yet).

More issues:
* The instruction (from the ifle `ocaml-variants.opam`) on how to update the opam switch:
```
opam install --assume-built ocaml-variants
```
freezes on my machine.
* When using this branch to compile `ocaml2mcore`, then I get an error on some programs. E.g.
```ocaml
let s = String.length "hello"
```
gives (when running `ocaml2mcore prog.ml`)
```
File "_none_", line 1, characters 22-29:
Error: This expression has type string/1
       but an expression was expected of type string/2
       string is abstract because no corresponding cmi file was found in path.
       File "_none_", line 1:
         Definition of type string/1
```
For now, `ocaml2mcore` can be built using the `gc_parallel_minor` branch.